### PR TITLE
feat(ml): add MLForge inference client

### DIFF
--- a/forgebreaker/ml/__init__.py
+++ b/forgebreaker/ml/__init__.py
@@ -11,6 +11,7 @@ from forgebreaker.ml.inference import (
     MLForgeClient,
     RecommendationScore,
     get_mlforge_client,
+    reset_mlforge_client,
 )
 
 __all__ = [
@@ -22,4 +23,5 @@ __all__ = [
     "extract_collection_features",
     "extract_deck_features",
     "get_mlforge_client",
+    "reset_mlforge_client",
 ]

--- a/forgebreaker/ml/inference.py
+++ b/forgebreaker/ml/inference.py
@@ -92,6 +92,12 @@ class MLForgeClient:
             data = response.json()
             scores = data.get("scores", [])
 
+            # Validate response length matches request
+            if len(scores) != len(features_list):
+                raise ValueError(
+                    f"API returned {len(scores)} scores for {len(features_list)} decks"
+                )
+
             return [
                 RecommendationScore(
                     deck_name=features_list[i].deck_name,
@@ -112,7 +118,7 @@ class MLForgeClient:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 response = await client.get(f"{self.base_url}/health")
                 return response.status_code == 200
-        except httpx.HTTPError:
+        except httpx.RequestError:
             return False
 
 
@@ -131,3 +137,13 @@ def get_mlforge_client() -> MLForgeClient:
     if _client is None:
         _client = MLForgeClient()
     return _client
+
+
+def reset_mlforge_client() -> None:
+    """
+    Reset the singleton client instance.
+
+    Primarily for testing purposes.
+    """
+    global _client
+    _client = None


### PR DESCRIPTION
## Summary
- Add `MLForgeClient` for calling MLForge recommendation API
- `score_deck()` - score a single deck
- `score_decks()` - batch score multiple decks
- `health_check()` - verify API availability
- `RecommendationScore` dataclass for results
- Singleton accessor `get_mlforge_client()`

## Test plan
- [x] Test client initialization (default URL, custom URL, custom timeout)
- [x] Test score_deck success and endpoint
- [x] Test score_deck handles missing response fields
- [x] Test score_decks with empty list
- [x] Test score_decks batch success
- [x] Test health_check success/failure/connection error
- [x] Test singleton behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)