### PR TITLE
feat(frontend): add deck browser with format selector

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,7 +228,7 @@ Scope: models, parser, api, frontend, ml, db
 
 <!-- Updated after each PR -->
 
-Last PR Merged: #18 frontend-setup
-Current PR: #19 frontend-collection
-Next PR: #20 frontend-deck-browser
+Last PR Merged: #19 frontend-collection
+Current PR: #20 frontend-deck-browser
+Next PR: #21 frontend-deck-detail
 Blockers: None

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { apiClient } from './api/client'
 import { CollectionImporter } from './components/CollectionImporter'
+import { DeckBrowser } from './components/DeckBrowser'
 
 function App() {
   const [userId, setUserId] = useState(() => {
@@ -99,19 +100,9 @@ function App() {
             </div>
 
             {/* Main Content */}
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-              <CollectionImporter userId={userId} />
-
+            <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
               <div className="space-y-6">
-                <div className="bg-white rounded-lg shadow p-6">
-                  <h3 className="text-lg font-medium text-gray-900">
-                    Browse Decks
-                  </h3>
-                  <p className="text-gray-500 mt-2">
-                    Explore meta decks and see which ones you can build.
-                  </p>
-                  <p className="text-sm text-gray-400 mt-4">Coming soon...</p>
-                </div>
+                <CollectionImporter userId={userId} />
 
                 <div className="bg-white rounded-lg shadow p-6">
                   <h3 className="text-lg font-medium text-gray-900">
@@ -122,6 +113,10 @@ function App() {
                   </p>
                   <p className="text-sm text-gray-400 mt-4">Coming soon...</p>
                 </div>
+              </div>
+
+              <div className="xl:col-span-2">
+                <DeckBrowser userId={userId} />
               </div>
             </div>
           </>

--- a/frontend/src/components/DeckBrowser.tsx
+++ b/frontend/src/components/DeckBrowser.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react'
+import type { DeckResponse } from '../api/client'
+import { useDecks } from '../hooks/useDecks'
+import { DeckCard } from './DeckCard'
+
+const FORMATS = [
+  { value: 'standard', label: 'Standard' },
+  { value: 'historic', label: 'Historic' },
+  { value: 'explorer', label: 'Explorer' },
+  { value: 'alchemy', label: 'Alchemy' },
+  { value: 'brawl', label: 'Brawl' },
+]
+
+interface DeckBrowserProps {
+  userId: string
+  onSelectDeck?: (deck: DeckResponse) => void
+}
+
+export function DeckBrowser({ userId, onSelectDeck }: DeckBrowserProps) {
+  const [format, setFormat] = useState('standard')
+  const { data, isLoading, error } = useDecks(format)
+
+  return (
+    <div className="bg-white rounded-lg shadow p-6">
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-xl font-semibold text-gray-900">Meta Decks</h2>
+        <select
+          value={format}
+          onChange={(e) => setFormat(e.target.value)}
+          className="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
+        >
+          {FORMATS.map((f) => (
+            <option key={f.value} value={f.value}>
+              {f.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {isLoading && (
+        <div className="text-center py-8">
+          <p className="text-gray-500">Loading decks...</p>
+        </div>
+      )}
+
+      {error && (
+        <div className="text-center py-8">
+          <p className="text-red-600">Failed to load decks. Is the backend running?</p>
+        </div>
+      )}
+
+      {data && data.decks.length === 0 && (
+        <div className="text-center py-8">
+          <p className="text-gray-500">No decks found for {format}.</p>
+        </div>
+      )}
+
+      {data && data.decks.length > 0 && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {data.decks.map((deck) => (
+            <DeckCard
+              key={deck.name}
+              deck={deck}
+              userId={userId}
+              onSelect={onSelectDeck}
+            />
+          ))}
+        </div>
+      )}
+
+      {data && (
+        <p className="text-sm text-gray-400 mt-4 text-center">
+          Showing {data.decks.length} decks for {format}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/DeckCard.tsx
+++ b/frontend/src/components/DeckCard.tsx
@@ -1,0 +1,89 @@
+import type { DeckResponse } from '../api/client'
+import { useDeckDistance } from '../hooks/useDecks'
+
+interface DeckCardProps {
+  deck: DeckResponse
+  userId: string
+  onSelect?: (deck: DeckResponse) => void
+}
+
+export function DeckCard({ deck, userId, onSelect }: DeckCardProps) {
+  const { data: distance, isLoading } = useDeckDistance(
+    userId,
+    deck.format,
+    deck.name
+  )
+
+  const completionPercent = distance?.completion_percentage ?? 0
+  const isComplete = distance?.is_complete ?? false
+
+  return (
+    <div
+      className="bg-white rounded-lg shadow p-4 hover:shadow-md transition-shadow cursor-pointer"
+      onClick={() => onSelect?.(deck)}
+    >
+      <div className="flex justify-between items-start mb-2">
+        <h3 className="text-lg font-medium text-gray-900">{deck.name}</h3>
+        <span className="px-2 py-1 text-xs font-medium rounded-full bg-gray-100 text-gray-600">
+          {deck.archetype}
+        </span>
+      </div>
+
+      {/* Win rate and meta share */}
+      <div className="flex gap-4 text-sm text-gray-500 mb-3">
+        {deck.win_rate != null && (
+          <span>Win rate: {(deck.win_rate * 100).toFixed(1)}%</span>
+        )}
+        {deck.meta_share != null && (
+          <span>Meta: {(deck.meta_share * 100).toFixed(1)}%</span>
+        )}
+      </div>
+
+      {/* Completion bar */}
+      <div className="mt-2">
+        <div className="flex justify-between text-sm mb-1">
+          <span className="text-gray-600">Collection Progress</span>
+          {isLoading ? (
+            <span className="text-gray-400">Loading...</span>
+          ) : (
+            <span
+              className={
+                isComplete
+                  ? 'text-green-600 font-medium'
+                  : 'text-gray-900 font-medium'
+              }
+            >
+              {completionPercent.toFixed(0)}%
+            </span>
+          )}
+        </div>
+        <div className="w-full bg-gray-200 rounded-full h-2">
+          <div
+            className={`h-2 rounded-full transition-all ${
+              isComplete
+                ? 'bg-green-500'
+                : completionPercent >= 75
+                  ? 'bg-yellow-500'
+                  : 'bg-indigo-500'
+            }`}
+            style={{ width: `${completionPercent}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Missing cards summary */}
+      {distance && !isComplete && (
+        <div className="mt-3 text-sm text-gray-500">
+          Missing {distance.missing_cards} cards ({distance.wildcard_cost.total}{' '}
+          wildcards)
+        </div>
+      )}
+
+      {isComplete && (
+        <div className="mt-3 text-sm text-green-600 font-medium">
+          You can build this deck!
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/hooks/useDecks.ts
+++ b/frontend/src/hooks/useDecks.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query'
+import { apiClient } from '../api/client'
+
+export function useDecks(format: string, limit = 50) {
+  return useQuery({
+    queryKey: ['decks', format, limit],
+    queryFn: () => apiClient.getDecks(format, limit),
+    enabled: !!format,
+  })
+}
+
+export function useDeckDistance(
+  userId: string,
+  format: string,
+  deckName: string
+) {
+  return useQuery({
+    queryKey: ['distance', userId, format, deckName],
+    queryFn: () => apiClient.getDeckDistance(userId, format, deckName),
+    enabled: !!userId && !!format && !!deckName,
+  })
+}


### PR DESCRIPTION
## Summary
- Add `DeckBrowser` component with format dropdown selector
- Add `DeckCard` component showing deck stats and completion progress
- Add `useDecks` and `useDeckDistance` hooks
- Display win rate, meta share, and buildability for each deck
- Show wildcard cost for incomplete decks

## Test plan
- [x] `npm run build` succeeds
- [x] TypeScript compiles without errors
- [x] Components handle loading/error states

🤖 Generated with [Claude Code](https://claude.com/claude-code)