### PR TITLE
feat(frontend): add chat advisor component

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,7 +228,7 @@ Scope: models, parser, api, frontend, ml, db
 
 <!-- Updated after each PR -->
 
-Last PR Merged: #20 frontend-deck-browser
-Current PR: #21 frontend-deck-detail
-Next PR: #22 frontend-chat
+Last PR Merged: #21 frontend-deck-detail
+Current PR: #22 frontend-chat
+Next PR: #23 jobs-meta-update
 Blockers: None

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import type { DeckResponse } from './api/client'
 import { apiClient } from './api/client'
+import { ChatAdvisor } from './components/ChatAdvisor'
 import { CollectionImporter } from './components/CollectionImporter'
 import { DeckBrowser } from './components/DeckBrowser'
 import { DeckDetail } from './components/DeckDetail'
@@ -107,15 +108,7 @@ function App() {
               <div className="space-y-6">
                 <CollectionImporter userId={userId} />
 
-                <div className="bg-white rounded-lg shadow p-6">
-                  <h3 className="text-lg font-medium text-gray-900">
-                    Chat Advisor
-                  </h3>
-                  <p className="text-gray-500 mt-2">
-                    Get AI-powered advice on deck building and card choices.
-                  </p>
-                  <p className="text-sm text-gray-400 mt-4">Coming soon...</p>
-                </div>
+                <ChatAdvisor userId={userId} />
               </div>
 
               <div className="xl:col-span-2">

--- a/frontend/src/components/ChatAdvisor.tsx
+++ b/frontend/src/components/ChatAdvisor.tsx
@@ -1,0 +1,130 @@
+import { useState, useRef, useEffect } from 'react'
+import type { ChatMessage } from '../api/client'
+import { useChat } from '../hooks/useChat'
+
+interface ChatAdvisorProps {
+  userId: string
+}
+
+function MessageBubble({ message }: { message: ChatMessage }) {
+  const isUser = message.role === 'user'
+
+  return (
+    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>
+      <div
+        className={`max-w-[80%] rounded-lg px-4 py-2 ${
+          isUser
+            ? 'bg-indigo-600 text-white'
+            : 'bg-gray-100 text-gray-900'
+        }`}
+      >
+        <p className="text-sm whitespace-pre-wrap">{message.content}</p>
+      </div>
+    </div>
+  )
+}
+
+export function ChatAdvisor({ userId }: ChatAdvisorProps) {
+  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [input, setInput] = useState('')
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+  const { mutate: sendMessage, isPending } = useChat(userId)
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages])
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!input.trim() || isPending) return
+
+    const userMessage: ChatMessage = { role: 'user', content: input.trim() }
+    const updatedMessages = [...messages, userMessage]
+    setMessages(updatedMessages)
+    setInput('')
+
+    sendMessage(updatedMessages, {
+      onSuccess: (response) => {
+        setMessages([...updatedMessages, response.message])
+      },
+      onError: (error) => {
+        setMessages([
+          ...updatedMessages,
+          {
+            role: 'assistant',
+            content: `Sorry, I encountered an error: ${error.message}`,
+          },
+        ])
+      },
+    })
+  }
+
+  return (
+    <div className="bg-white rounded-lg shadow flex flex-col h-96">
+      {/* Header */}
+      <div className="px-4 py-3 border-b border-gray-200">
+        <h3 className="text-lg font-medium text-gray-900">Deck Advisor</h3>
+        <p className="text-sm text-gray-500">
+          Ask for deck building advice based on your collection
+        </p>
+      </div>
+
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-3">
+        {messages.length === 0 && (
+          <div className="text-center text-gray-400 text-sm py-8">
+            <p>Start a conversation to get deck advice.</p>
+            <p className="mt-2">Try asking:</p>
+            <ul className="mt-1 space-y-1">
+              <li>"What decks can I build with my collection?"</li>
+              <li>"Which deck is closest to completing?"</li>
+              <li>"What cards should I craft next?"</li>
+            </ul>
+          </div>
+        )}
+        {messages.map((message, index) => (
+          <MessageBubble key={index} message={message} />
+        ))}
+        {isPending && (
+          <div className="flex justify-start">
+            <div className="bg-gray-100 rounded-lg px-4 py-2">
+              <div className="flex space-x-1">
+                <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" />
+                <div
+                  className="w-2 h-2 bg-gray-400 rounded-full animate-bounce"
+                  style={{ animationDelay: '0.1s' }}
+                />
+                <div
+                  className="w-2 h-2 bg-gray-400 rounded-full animate-bounce"
+                  style={{ animationDelay: '0.2s' }}
+                />
+              </div>
+            </div>
+          </div>
+        )}
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Input */}
+      <form onSubmit={handleSubmit} className="p-4 border-t border-gray-200">
+        <div className="flex gap-2">
+          <input
+            type="text"
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Ask about deck building..."
+            disabled={isPending}
+            className="flex-1 px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 disabled:bg-gray-50 disabled:text-gray-500"
+          />
+          <button
+            type="submit"
+            disabled={!input.trim() || isPending}
+            className="px-4 py-2 bg-indigo-600 text-white font-medium rounded-lg hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Send
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query'
+import type { ChatMessage } from '../api/client'
+import { apiClient } from '../api/client'
+
+export function useChat(userId: string) {
+  return useMutation({
+    mutationFn: (messages: ChatMessage[]) => apiClient.chat(userId, messages),
+  })
+}


### PR DESCRIPTION
## Summary
- Add ChatAdvisor component with real-time chat interface
- Implement useChat hook using react-query mutation
- User/assistant message bubbles with different styling
- Loading indicator with animated bouncing dots
- Suggested prompts for new users (deck recommendations, card crafting)

## Test plan
- [ ] Type message and click Send
- [ ] Verify user message appears immediately
- [ ] Verify loading indicator shows while waiting
- [ ] Verify assistant response appears after API call
- [ ] Build passes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)