### PR TITLE
feat(jobs): add scheduled meta deck refresh job

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,7 +228,7 @@ Scope: models, parser, api, frontend, ml, db
 
 <!-- Updated after each PR -->
 
-Last PR Merged: #21 frontend-deck-detail
-Current PR: #22 frontend-chat
-Next PR: #23 jobs-meta-update
+Last PR Merged: #22 frontend-chat
+Current PR: #23 jobs-meta-update
+Next PR: #24 deployment
 Blockers: None

--- a/forgebreaker/jobs/__init__.py
+++ b/forgebreaker/jobs/__init__.py
@@ -1,0 +1,5 @@
+"""Scheduled jobs for ForgeBreaker."""
+
+from forgebreaker.jobs.update_meta import run_meta_update
+
+__all__ = ["run_meta_update"]

--- a/forgebreaker/jobs/update_meta.py
+++ b/forgebreaker/jobs/update_meta.py
@@ -1,0 +1,101 @@
+"""
+Scheduled job to refresh meta deck data.
+
+Fetches current meta decks from MTGGoldfish and syncs to database.
+Can be run as a standalone script or called from a scheduler.
+"""
+
+import asyncio
+import logging
+
+import httpx
+
+from forgebreaker.db.database import async_session_factory
+from forgebreaker.db.operations import sync_meta_decks
+from forgebreaker.scrapers.mtggoldfish import VALID_FORMATS, fetch_meta_decks
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_DECKS_PER_FORMAT = 15
+
+
+async def update_format(format_name: str, limit: int, client: httpx.Client) -> int:
+    """
+    Update meta decks for a single format.
+
+    Args:
+        format_name: Format to update (standard, historic, etc.)
+        limit: Max number of decks to fetch
+        client: HTTP client for requests
+
+    Returns:
+        Number of decks synced
+    """
+    logger.info("Fetching meta decks for %s...", format_name)
+
+    try:
+        decks = fetch_meta_decks(format_name, limit=limit, client=client)
+        logger.info("Fetched %d decks for %s", len(decks), format_name)
+
+        async with async_session_factory() as session:
+            count = await sync_meta_decks(session, format_name, decks)
+            await session.commit()
+
+        logger.info("Synced %d decks for %s", count, format_name)
+        return count
+
+    except httpx.HTTPError as e:
+        logger.error("HTTP error fetching %s: %s", format_name, e)
+        return 0
+    except Exception as e:
+        logger.error("Error updating %s: %s", format_name, e)
+        return 0
+
+
+async def run_meta_update(
+    formats: list[str] | None = None,
+    limit: int = DEFAULT_DECKS_PER_FORMAT,
+) -> dict[str, int]:
+    """
+    Run meta deck update for all or specified formats.
+
+    Args:
+        formats: List of formats to update. If None, updates all valid formats.
+        limit: Max number of decks per format
+
+    Returns:
+        Dict mapping format name to number of decks synced
+    """
+    if formats is None:
+        formats = list(VALID_FORMATS)
+
+    results: dict[str, int] = {}
+
+    with httpx.Client(
+        headers={"User-Agent": "ForgeBreaker/1.0"},
+        follow_redirects=True,
+        timeout=30.0,
+    ) as client:
+        for format_name in formats:
+            if format_name not in VALID_FORMATS:
+                logger.warning("Skipping invalid format: %s", format_name)
+                continue
+
+            results[format_name] = await update_format(format_name, limit, client)
+
+    total = sum(results.values())
+    logger.info("Meta update complete. Total decks synced: %d", total)
+    return results
+
+
+def main() -> None:
+    """CLI entry point for running meta update."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
+    asyncio.run(run_meta_update())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,0 +1,131 @@
+"""Tests for scheduled jobs."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from forgebreaker.jobs.update_meta import run_meta_update, update_format
+from forgebreaker.models.deck import MetaDeck
+
+
+@pytest.fixture
+def sample_meta_deck() -> MetaDeck:
+    return MetaDeck(
+        name="Mono-Red Aggro",
+        archetype="aggro",
+        format="standard",
+        cards={"Lightning Bolt": 4, "Mountain": 20},
+        sideboard={},
+        meta_share=0.12,
+        source_url="https://example.com",
+    )
+
+
+class TestUpdateFormat:
+    @pytest.mark.asyncio
+    async def test_update_format_success(self, sample_meta_deck: MetaDeck):
+        """Test successful format update."""
+        mock_client = MagicMock()
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session.commit = AsyncMock()
+
+        with (
+            patch(
+                "forgebreaker.jobs.update_meta.fetch_meta_decks",
+                return_value=[sample_meta_deck],
+            ),
+            patch(
+                "forgebreaker.jobs.update_meta.async_session_factory",
+                return_value=mock_session,
+            ),
+            patch(
+                "forgebreaker.jobs.update_meta.sync_meta_decks",
+                new_callable=AsyncMock,
+                return_value=1,
+            ),
+        ):
+            result = await update_format("standard", limit=10, client=mock_client)
+            assert result == 1
+
+    @pytest.mark.asyncio
+    async def test_update_format_http_error(self):
+        """Test format update handles HTTP errors."""
+        import httpx
+
+        mock_client = MagicMock()
+
+        with patch(
+            "forgebreaker.jobs.update_meta.fetch_meta_decks",
+            side_effect=httpx.HTTPError("Network error"),
+        ):
+            result = await update_format("standard", limit=10, client=mock_client)
+            assert result == 0
+
+
+class TestRunMetaUpdate:
+    @pytest.mark.asyncio
+    async def test_run_meta_update_all_formats(self, sample_meta_deck: MetaDeck):
+        """Test updating all formats."""
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session.commit = AsyncMock()
+
+        with (
+            patch(
+                "forgebreaker.jobs.update_meta.fetch_meta_decks",
+                return_value=[sample_meta_deck],
+            ),
+            patch(
+                "forgebreaker.jobs.update_meta.async_session_factory",
+                return_value=mock_session,
+            ),
+            patch(
+                "forgebreaker.jobs.update_meta.sync_meta_decks",
+                new_callable=AsyncMock,
+                return_value=1,
+            ),
+        ):
+            results = await run_meta_update()
+
+            # All valid formats should be updated
+            assert "standard" in results
+            assert "historic" in results
+            assert "explorer" in results
+            assert "timeless" in results
+
+    @pytest.mark.asyncio
+    async def test_run_meta_update_specific_formats(self, sample_meta_deck: MetaDeck):
+        """Test updating specific formats only."""
+        mock_session = AsyncMock()
+        mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_session.__aexit__ = AsyncMock(return_value=None)
+        mock_session.commit = AsyncMock()
+
+        with (
+            patch(
+                "forgebreaker.jobs.update_meta.fetch_meta_decks",
+                return_value=[sample_meta_deck],
+            ),
+            patch(
+                "forgebreaker.jobs.update_meta.async_session_factory",
+                return_value=mock_session,
+            ),
+            patch(
+                "forgebreaker.jobs.update_meta.sync_meta_decks",
+                new_callable=AsyncMock,
+                return_value=1,
+            ),
+        ):
+            results = await run_meta_update(formats=["standard"])
+
+            assert "standard" in results
+            assert "historic" not in results
+
+    @pytest.mark.asyncio
+    async def test_run_meta_update_skips_invalid_format(self):
+        """Test that invalid formats are skipped."""
+        results = await run_meta_update(formats=["invalid_format"])
+        assert "invalid_format" not in results


### PR DESCRIPTION
## Summary
- Add jobs module for scheduled tasks
- Implement `run_meta_update` function that fetches and syncs meta decks
- Support updating all formats or specific formats
- Handle HTTP errors gracefully with logging
- CLI entry point for standalone execution (`python -m forgebreaker.jobs.update_meta`)

## Test plan
- [ ] 5 unit tests with mocked dependencies
- [ ] All tests pass
- [ ] ruff check passes
- [ ] mypy passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)