### PR TITLE
feat(parser): add collection import parser with POST endpoint

### DIFF
--- a/forgebreaker/api/collection.py
+++ b/forgebreaker/api/collection.py
@@ -4,7 +4,7 @@ Collection API endpoints.
 Provides CRUD operations for user card collections.
 """
 
-from typing import Annotated
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
@@ -17,6 +17,7 @@ from forgebreaker.db import (
     update_collection_cards,
 )
 from forgebreaker.db.database import get_session
+from forgebreaker.parsers.collection_import import parse_collection_text
 
 router = APIRouter(prefix="/collection", tags=["collection"])
 
@@ -37,6 +38,33 @@ class CollectionUpdateRequest(BaseModel):
         description="Map of card names to quantities",
         examples=[{"Lightning Bolt": 4, "Mountain": 20}],
     )
+
+
+class CollectionImportRequest(BaseModel):
+    """Request model for importing a collection from text."""
+
+    text: str = Field(
+        ...,
+        description="Raw collection text (CSV, simple format, or Arena export)",
+        examples=["4 Lightning Bolt\n4 Monastery Swiftspear"],
+    )
+    format: Literal["auto", "simple", "csv", "arena"] = Field(
+        default="auto",
+        description="Format hint: auto-detect, simple (4 Card), csv, or arena",
+    )
+    merge: bool = Field(
+        default=False,
+        description="If true, merge with existing collection (keep max qty)",
+    )
+
+
+class ImportResponse(BaseModel):
+    """Response model for collection import."""
+
+    user_id: str
+    cards_imported: int
+    total_cards: int
+    cards: dict[str, int] = Field(default_factory=dict)
 
 
 class DeleteResponse(BaseModel):
@@ -115,3 +143,55 @@ async def delete_user_collection(
     """
     deleted = await delete_collection(session, user_id)
     return DeleteResponse(deleted=deleted)
+
+
+@router.post("/{user_id}/import", response_model=ImportResponse)
+async def import_user_collection(
+    user_id: str,
+    request: CollectionImportRequest,
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> ImportResponse:
+    """
+    Import a collection from text in various formats.
+
+    Supported formats (auto-detected):
+    - Simple: "4 Lightning Bolt" or "4x Lightning Bolt"
+    - CSV: "Card Name",Quantity,Set (MTGGoldfish/DeckStats style)
+    - Arena: "4 Lightning Bolt (LEB) 163"
+
+    If merge=true, keeps the maximum quantity for each card
+    between existing and imported collections.
+    """
+    if not request.text or not request.text.strip():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Import text cannot be empty",
+        )
+
+    # Parse the import text
+    parsed_cards = parse_collection_text(request.text, request.format)
+
+    if not parsed_cards:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No valid cards found in import text",
+        )
+
+    # If merge mode, combine with existing collection
+    if request.merge:
+        existing = await get_collection(session, user_id)
+        if existing:
+            existing_model = collection_to_model(existing)
+            for name, qty in existing_model.cards.items():
+                parsed_cards[name] = max(parsed_cards.get(name, 0), qty)
+
+    # Save the collection
+    db_collection = await update_collection_cards(session, user_id, parsed_cards)
+    model = collection_to_model(db_collection)
+
+    return ImportResponse(
+        user_id=user_id,
+        cards_imported=len(parsed_cards),
+        total_cards=model.total_cards(),
+        cards=model.cards,
+    )

--- a/forgebreaker/parsers/__init__.py
+++ b/forgebreaker/parsers/__init__.py
@@ -3,9 +3,17 @@ from forgebreaker.parsers.arena_export import (
     parse_arena_export,
     parse_arena_to_collection,
 )
+from forgebreaker.parsers.collection_import import (
+    merge_collections,
+    parse_collection_text,
+    parse_multiple_decks,
+)
 
 __all__ = [
     "cards_to_collection",
+    "merge_collections",
     "parse_arena_export",
     "parse_arena_to_collection",
+    "parse_collection_text",
+    "parse_multiple_decks",
 ]

--- a/forgebreaker/parsers/collection_import.py
+++ b/forgebreaker/parsers/collection_import.py
@@ -1,0 +1,211 @@
+"""
+Parser for various collection export formats.
+
+Supports:
+- Simple format: "4 Lightning Bolt" or "4x Lightning Bolt"
+- CSV format: "Card Name",Quantity,Set (MTGGoldfish style)
+- Arena deck export format (delegates to arena_export.py)
+"""
+
+import csv
+import re
+from io import StringIO
+from typing import Literal
+
+from forgebreaker.models.collection import Collection
+
+# Pattern: "4 Lightning Bolt" or "4x Lightning Bolt" or "4X Lightning Bolt"
+# Groups: (quantity, card_name)
+SIMPLE_PATTERN = re.compile(r"^(\d+)x?\s+(.+)$", re.IGNORECASE)
+
+
+def parse_simple_format(text: str) -> dict[str, int]:
+    """
+    Parse simple "quantity card_name" format.
+
+    Accepts:
+        - "4 Lightning Bolt"
+        - "4x Lightning Bolt"
+        - "4X Lightning Bolt"
+
+    Returns:
+        Dict mapping card names to quantities.
+    """
+    cards: dict[str, int] = {}
+
+    for line in text.strip().split("\n"):
+        line = line.strip()
+        if not line:
+            continue
+
+        match = SIMPLE_PATTERN.match(line)
+        if match:
+            quantity = int(match.group(1))
+            name = match.group(2).strip()
+            if name:
+                # Aggregate duplicates
+                cards[name] = cards.get(name, 0) + quantity
+
+    return cards
+
+
+def parse_csv_format(text: str) -> dict[str, int]:
+    """
+    Parse CSV collection export format.
+
+    Expected columns (flexible ordering):
+        - Card Name / Name / Card
+        - Quantity / Count / Qty
+        - Set (optional)
+
+    Returns:
+        Dict mapping card names to quantities.
+    """
+    cards: dict[str, int] = {}
+
+    # Use StringIO to parse CSV from text
+    reader = csv.DictReader(StringIO(text))
+
+    if not reader.fieldnames:
+        return cards
+
+    # Find the card name column (case-insensitive)
+    name_col = None
+    for col in reader.fieldnames:
+        if col.lower() in ("card name", "name", "card"):
+            name_col = col
+            break
+
+    # Find the quantity column (case-insensitive)
+    qty_col = None
+    for col in reader.fieldnames:
+        if col.lower() in ("quantity", "count", "qty"):
+            qty_col = col
+            break
+
+    if not name_col:
+        return cards
+
+    for row in reader:
+        name = row.get(name_col, "").strip()
+        if not name:
+            continue
+
+        # Default to 1 if no quantity column
+        qty_str = row.get(qty_col, "1") if qty_col else "1"
+        try:
+            quantity = int(qty_str) if qty_str else 1
+        except ValueError:
+            quantity = 1
+
+        if quantity > 0:
+            cards[name] = cards.get(name, 0) + quantity
+
+    return cards
+
+
+def detect_format(text: str) -> Literal["simple", "csv", "arena"]:
+    """
+    Auto-detect the format of collection text.
+
+    Returns:
+        - "csv" if text appears to be CSV (comma-separated with header)
+        - "arena" if text matches Arena deck format (with set codes)
+        - "simple" otherwise
+    """
+    text = text.strip()
+    if not text:
+        return "simple"
+
+    lines = text.split("\n")
+    first_line = lines[0].strip()
+
+    # Check for CSV: first line has commas and looks like a header
+    if "," in first_line:
+        lower_first = first_line.lower()
+        if any(h in lower_first for h in ("card name", "name", "quantity", "count")):
+            return "csv"
+
+    # Check for Arena format: lines have set codes in parentheses
+    # Pattern: "4 Card Name (SET) 123"
+    arena_pattern = re.compile(r"^\d+\s+.+\s+\([A-Z0-9]+\)\s+\S+$")
+    for line in lines[:10]:  # Check first 10 lines
+        line = line.strip()
+        if line and arena_pattern.match(line):
+            return "arena"
+
+    return "simple"
+
+
+def parse_collection_text(
+    text: str, format_hint: Literal["auto", "simple", "csv", "arena"] = "auto"
+) -> dict[str, int]:
+    """
+    Parse collection text in various formats.
+
+    Args:
+        text: Raw collection text (pasted from export)
+        format_hint: Format to use, or "auto" to detect
+
+    Returns:
+        Dict mapping card names to quantities.
+    """
+    if not text or not text.strip():
+        return {}
+
+    # Determine format
+    if format_hint == "auto":
+        format_hint = detect_format(text)
+
+    # Parse based on format
+    if format_hint == "csv":
+        return parse_csv_format(text)
+    elif format_hint == "arena":
+        # Delegate to arena parser, then convert to dict
+        from forgebreaker.parsers.arena_export import parse_arena_to_collection
+
+        collection = parse_arena_to_collection(text)
+        return collection.cards
+    else:
+        return parse_simple_format(text)
+
+
+def merge_collections(base: dict[str, int], new: dict[str, int]) -> dict[str, int]:
+    """
+    Merge two collections, keeping the maximum quantity for each card.
+
+    This is useful when importing from multiple decks - we want the
+    highest count seen for each card as the minimum collection size.
+    """
+    result = dict(base)
+    for name, qty in new.items():
+        result[name] = max(result.get(name, 0), qty)
+    return result
+
+
+def parse_multiple_decks(deck_texts: list[str]) -> Collection:
+    """
+    Parse multiple deck exports and merge into a collection.
+
+    Takes the maximum quantity of each card across all decks.
+    This represents the minimum collection needed to build all decks.
+
+    Args:
+        deck_texts: List of deck export texts
+
+    Returns:
+        Merged collection with max quantities
+    """
+    merged: dict[str, int] = {}
+
+    for text in deck_texts:
+        if not text or not text.strip():
+            continue
+        deck_cards = parse_collection_text(text, "auto")
+        merged = merge_collections(merged, deck_cards)
+
+    collection = Collection()
+    for name, qty in merged.items():
+        collection.add_card(name, qty)
+
+    return collection


### PR DESCRIPTION
## Summary
- Add `collection_import.py` parser supporting multiple formats (simple, CSV, Arena deck)
- Add `POST /api/collection/{user_id}/import` endpoint with auto-format detection
- Support merge mode to combine with existing collection (keeps max quantities)

## Test plan
- [x] Unit tests for all parser formats (simple, CSV, Arena)
- [x] Tests for format auto-detection
- [x] Tests for collection merging
- [x] Full test suite passes (221 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)