### PR TITLE
feat(frontend): add tabbed collection importer UI

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -25,6 +25,14 @@ export interface CollectionResponse {
   user_id: string
   total_cards: number
   unique_cards: number
+  cards?: Record<string, number>
+}
+
+export interface ImportResponse {
+  user_id: string
+  cards_imported: number
+  total_cards: number
+  cards: Record<string, number>
 }
 
 export interface DistanceResponse {
@@ -106,11 +114,13 @@ class ApiClient {
 
   async importCollection(
     userId: string,
-    arenaExport: string
-  ): Promise<CollectionResponse> {
-    return this.request(`/collection/${userId}`, {
+    text: string,
+    format: 'auto' | 'simple' | 'csv' | 'arena' = 'auto',
+    merge = false
+  ): Promise<ImportResponse> {
+    return this.request(`/collection/${userId}/import`, {
       method: 'POST',
-      body: JSON.stringify({ arena_export: arenaExport }),
+      body: JSON.stringify({ text, format, merge }),
     })
   }
 


### PR DESCRIPTION
## Summary
- Add tabs for "From Tracker Export" / "From Deck Lists"
- Explain Arena doesn't have native collection export
- Link to popular trackers (MTGA Assistant, MTGGoldfish, MTGAHelper)
- Show format examples for each import method
- Support multi-deck import with "Add Another Deck" button
- Update API client and hook for new import endpoint

## Test plan
- [x] Frontend builds successfully
- [x] Tab switching works
- [x] Deck list management (add/remove)
- [ ] Manual test with tracker export paste
- [ ] Manual test with deck import

🤖 Generated with [Claude Code](https://claude.com/claude-code)