### PR TITLE
fix(db): delete cards before insert to avoid unique constraint

### DIFF
--- a/forgebreaker/db/operations.py
+++ b/forgebreaker/db/operations.py
@@ -79,7 +79,11 @@ async def update_collection_cards(
         raise RuntimeError(msg)
     collection = loaded
 
-    # Clear existing cards
+    # Delete existing cards from database first
+    await session.execute(
+        delete(CardOwnershipDB).where(CardOwnershipDB.collection_id == collection.id)
+    )
+    # Clear the ORM list to stay in sync
     collection.cards.clear()
 
     # Add new cards


### PR DESCRIPTION
## Summary
Fix database unique constraint violation when updating collections.

The previous implementation used `collection.cards.clear()` which only cleared the ORM list but didn't immediately delete from the database. When new cards with the same names were added, it caused a duplicate key violation.

Now explicitly deletes from the database first using a DELETE query.

## Test plan
- [x] All 11 collection API tests pass
- [x] Full test suite passes (221 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)