### PR TITLE
feat(frontend): add chat help panel documenting all tools

### DIFF
--- a/frontend/src/components/ChatAdvisor.tsx
+++ b/frontend/src/components/ChatAdvisor.tsx
@@ -6,6 +6,88 @@ interface ChatAdvisorProps {
   userId: string
 }
 
+const HELP_TOPICS = [
+  {
+    title: 'Search Your Collection',
+    description: 'Find cards you own by name, color, or type.',
+    examples: ['Do I have any goblins?', 'Show me my red creatures', 'What shrines do I own?'],
+  },
+  {
+    title: 'Build a Deck',
+    description: 'Create a 60-card deck using only cards you own. No wildcards needed.',
+    examples: ['Build me a shrine deck', 'Make a goblin tribal deck', 'Create something fun with dragons'],
+  },
+  {
+    title: 'Find Synergies',
+    description: 'Discover cards that work well together.',
+    examples: ['What pairs well with Sheoldred?', 'Find synergies for my sacrifice deck'],
+  },
+  {
+    title: 'Export to Arena',
+    description: 'Get a deck list you can import directly into MTG Arena.',
+    examples: ['Export this deck for Arena', 'Give me the import text'],
+  },
+  {
+    title: 'Meta Deck Recommendations',
+    description: 'Find competitive decks you can complete with your collection.',
+    examples: ['What meta decks can I build?', 'Show me Standard decks I\'m close to'],
+  },
+  {
+    title: 'Deck Completion Details',
+    description: 'See exactly what cards you need to finish a specific deck.',
+    examples: ['How close am I to Mono Red Aggro?', 'What do I need for Esper Control?'],
+  },
+  {
+    title: 'Browse Meta Decks',
+    description: 'See the top competitive decks for any format.',
+    examples: ['What are the top decks in Standard?', 'Show me Historic meta decks'],
+  },
+  {
+    title: 'Collection Stats',
+    description: 'View your collection overview and statistics.',
+    examples: ['How many cards do I have?', 'Show me my collection statistics'],
+  },
+]
+
+function HelpPanel({ onClose }: { onClose: () => void }) {
+  return (
+    <div className="absolute inset-0 bg-white z-10 overflow-y-auto">
+      <div className="p-4">
+        <div className="flex justify-between items-center mb-4">
+          <h4 className="text-lg font-medium text-gray-900">What can I ask?</h4>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-600"
+            aria-label="Close help"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+        <div className="space-y-4">
+          {HELP_TOPICS.map((topic) => (
+            <div key={topic.title} className="border-b border-gray-100 pb-3 last:border-0">
+              <h5 className="font-medium text-gray-800 text-sm">{topic.title}</h5>
+              <p className="text-xs text-gray-500 mt-1">{topic.description}</p>
+              <div className="mt-2 flex flex-wrap gap-1">
+                {topic.examples.map((example) => (
+                  <span
+                    key={example}
+                    className="inline-block text-xs bg-gray-100 text-gray-600 px-2 py-1 rounded"
+                  >
+                    "{example}"
+                  </span>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
 function MessageBubble({ message }: { message: ChatMessage }) {
   const isUser = message.role === 'user'
 
@@ -27,6 +109,7 @@ function MessageBubble({ message }: { message: ChatMessage }) {
 export function ChatAdvisor({ userId }: ChatAdvisorProps) {
   const [messages, setMessages] = useState<ChatMessage[]>([])
   const [input, setInput] = useState('')
+  const [showHelp, setShowHelp] = useState(false)
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const { mutate: sendMessage, isPending } = useChat(userId)
 
@@ -60,13 +143,28 @@ export function ChatAdvisor({ userId }: ChatAdvisorProps) {
   }
 
   return (
-    <div className="bg-white rounded-lg shadow flex flex-col h-96">
+    <div className="bg-white rounded-lg shadow flex flex-col h-96 relative">
+      {/* Help Panel Overlay */}
+      {showHelp && <HelpPanel onClose={() => setShowHelp(false)} />}
+
       {/* Header */}
-      <div className="px-4 py-3 border-b border-gray-200">
-        <h3 className="text-lg font-medium text-gray-900">Deck Advisor</h3>
-        <p className="text-sm text-gray-500">
-          Ask for deck building advice based on your collection
-        </p>
+      <div className="px-4 py-3 border-b border-gray-200 flex justify-between items-start">
+        <div>
+          <h3 className="text-lg font-medium text-gray-900">Deck Advisor</h3>
+          <p className="text-sm text-gray-500">
+            Ask for deck building advice based on your collection
+          </p>
+        </div>
+        <button
+          onClick={() => setShowHelp(true)}
+          className="text-gray-400 hover:text-indigo-600 p-1"
+          aria-label="Show help"
+          title="What can I ask?"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+          </svg>
+        </button>
       </div>
 
       {/* Messages */}
@@ -76,10 +174,16 @@ export function ChatAdvisor({ userId }: ChatAdvisorProps) {
             <p>Start a conversation to get deck advice.</p>
             <p className="mt-2">Try asking:</p>
             <ul className="mt-1 space-y-1">
-              <li>"What decks can I build with my collection?"</li>
-              <li>"Which deck is closest to completing?"</li>
-              <li>"What cards should I craft next?"</li>
+              <li>"Build me a goblin deck"</li>
+              <li>"What meta decks can I build?"</li>
+              <li>"Find synergies for Sheoldred"</li>
             </ul>
+            <button
+              onClick={() => setShowHelp(true)}
+              className="mt-4 text-indigo-600 hover:text-indigo-800 underline"
+            >
+              See all things I can help with
+            </button>
           </div>
         )}
         {messages.map((message, index) => (


### PR DESCRIPTION
## Summary

- Adds a help panel to ChatAdvisor documenting all 8 MCP tools in plain English
- Users can click the "?" button in the header or "See all things I can help with" link
- Each tool shows: title, description, and example prompts

## Tools Documented

| Tool | Description |
|------|-------------|
| Search Your Collection | Find cards by name, color, or type |
| Build a Deck | Create a 60-card deck from owned cards |
| Find Synergies | Discover cards that work well together |
| Export to Arena | Get Arena-importable deck text |
| Meta Deck Recommendations | Find meta decks you can complete |
| Deck Completion Details | See what cards you need for a specific deck |
| Browse Meta Decks | See top competitive decks by format |
| Collection Stats | View collection overview and statistics |

## Test plan

- [ ] Click "?" button in ChatAdvisor header - help panel opens
- [ ] Click "See all things I can help with" in empty state - help panel opens
- [ ] Click X button in help panel - closes and returns to chat
- [ ] Verify all 8 tools are documented with examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)