### PR TITLE
fix(mcp): wire card database into execute_tool

### DIFF
--- a/forgebreaker/mcp/tools.py
+++ b/forgebreaker/mcp/tools.py
@@ -11,8 +11,6 @@ from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-logger = logging.getLogger(__name__)
-
 from forgebreaker.analysis.distance import calculate_deck_distance
 from forgebreaker.analysis.ranker import rank_decks
 from forgebreaker.db import (
@@ -43,6 +41,7 @@ from forgebreaker.services.synergy_finder import (
     format_synergy_results,
 )
 
+logger = logging.getLogger(__name__)
 
 # Cached card database and format legality (loaded once)
 _card_db_cache: dict[str, dict[str, Any]] | None = None

--- a/railway.toml
+++ b/railway.toml
@@ -2,8 +2,8 @@
 builder = "nixpacks"
 
 [deploy]
-startCommand = "uvicorn forgebreaker.main:app --host 0.0.0.0 --port $PORT"
+startCommand = "python -m forgebreaker.jobs.download_cards && uvicorn forgebreaker.main:app --host 0.0.0.0 --port $PORT"
 healthcheckPath = "/health"
-healthcheckTimeout = 30
+healthcheckTimeout = 120
 restartPolicyType = "on_failure"
 restartPolicyMaxRetries = 3


### PR DESCRIPTION
## Summary

Fixes bug where `build_deck`, `search_collection`, `find_synergies`, and `export_to_arena` tools were returning empty results because the card database wasn't being loaded.

## Root Cause

In `execute_tool()`, the `card_db` and `format_legality` parameters were being passed as empty dictionaries:

```python
# Before (broken)
deck_card_db: dict[str, dict[str, Any]] = {}
format_legality: dict[str, set[str]] = {}
```

The card database service from PR #42 was never wired into the tool execution.

## Fix

- Added `_get_card_db_safe()` and `_get_format_legality_safe()` helper functions
- These load the Scryfall card database with graceful fallback if file missing
- Updated all relevant tools in `execute_tool()` to use the real card database
- Updated `railway.toml` to download card database on startup

## Test plan

- [ ] Deploy to Railway
- [ ] Ask "build me a shrine deck" - should now find shrines in collection
- [ ] Ask "search for goblin" - should return cards from collection

🤖 Generated with [Claude Code](https://claude.com/claude-code)