### PR TITLE
perf(tools): slim tool schemas to reduce token overhead

### DIFF
--- a/forgebreaker/mcp/tools.py
+++ b/forgebreaker/mcp/tools.py
@@ -142,87 +142,63 @@ class ToolDefinition:
 TOOL_DEFINITIONS: list[ToolDefinition] = [
     ToolDefinition(
         name="get_deck_recommendations",
-        description=(
-            "Get ranked deck recommendations based on the user's collection. "
-            "Returns decks sorted by how easy they are to build with current cards."
-        ),
+        description="Get ranked deck recommendations based on user's collection.",
         parameters={
             "type": "object",
             "properties": {
-                "user_id": {
-                    "type": "string",
-                    "description": "The user's ID",
-                },
                 "format": {
                     "type": "string",
-                    "description": "Game format (standard, historic, explorer, etc.)",
+                    "description": "Game format",
                 },
                 "limit": {
                     "type": "integer",
-                    "description": "Maximum number of recommendations to return",
+                    "description": "Max recommendations",
                     "default": 5,
                 },
             },
-            "required": ["user_id", "format"],
+            "required": ["format"],
         },
     ),
     ToolDefinition(
         name="calculate_deck_distance",
-        description=(
-            "Calculate how far a user's collection is from completing a specific deck. "
-            "Returns missing cards, wildcard costs, and completion percentage."
-        ),
+        description="Calculate missing cards and wildcard cost for a deck.",
         parameters={
             "type": "object",
             "properties": {
-                "user_id": {
-                    "type": "string",
-                    "description": "The user's ID",
-                },
                 "format": {
                     "type": "string",
-                    "description": "Game format the deck belongs to",
+                    "description": "Game format",
                 },
                 "deck_name": {
                     "type": "string",
-                    "description": "Name of the deck to check",
+                    "description": "Deck name",
                 },
             },
-            "required": ["user_id", "format", "deck_name"],
+            "required": ["format", "deck_name"],
         },
     ),
     ToolDefinition(
         name="get_collection_stats",
-        description=(
-            "Get statistics about a user's card collection. Returns total cards and unique cards."
-        ),
+        description="Get card collection statistics.",
         parameters={
             "type": "object",
-            "properties": {
-                "user_id": {
-                    "type": "string",
-                    "description": "The user's ID",
-                },
-            },
-            "required": ["user_id"],
+            "properties": {},
+            "required": [],
         },
     ),
     ToolDefinition(
         name="list_meta_decks",
-        description=(
-            "List available meta decks for a format. "
-            "Returns deck names, archetypes, win rates, and meta share."
-        ),
+        description="List available meta decks for a format.",
         parameters={
             "type": "object",
             "properties": {
                 "format": {
                     "type": "string",
-                    "description": "Game format (standard, historic, explorer, etc.)",
+                    "description": "Game format",
                 },
                 "limit": {
                     "type": "integer",
-                    "description": "Maximum number of decks to return",
+                    "description": "Max decks",
                     "default": 10,
                 },
             },
@@ -231,54 +207,35 @@ TOOL_DEFINITIONS: list[ToolDefinition] = [
     ),
     ToolDefinition(
         name="search_collection",
-        description=(
-            "Search the user's card collection for cards matching specific criteria. "
-            "Use for queries like: 'how many black dragons?', 'what creatures have flying?', "
-            "'show me my 3-drops', 'what cards draw cards?', 'what mono-red cards do I have?', "
-            "'what Standard-legal rares do I own?'"
-        ),
+        description="Search user's collection for cards matching criteria.",
         parameters={
             "type": "object",
             "properties": {
-                "user_id": {
-                    "type": "string",
-                    "description": "The user's ID",
-                },
                 "name_contains": {
                     "type": "string",
-                    "description": "Find cards with this text in the name (case-insensitive)",
+                    "description": "Text in card name",
                 },
                 "oracle_text": {
                     "type": "string",
-                    "description": (
-                        "Find cards with this text in the rules text. "
-                        "Examples: 'draw a card', 'destroy target', 'create a token'"
-                    ),
+                    "description": "Text in rules text",
                 },
                 "card_type": {
                     "type": "string",
-                    "description": (
-                        "Filter by type line (Creature, Instant, Dragon, Goblin, Shrine, etc.)"
-                    ),
+                    "description": "Type line filter",
                 },
                 "colors": {
                     "type": "array",
                     "items": {"type": "string", "enum": ["W", "U", "B", "R", "G"]},
-                    "description": (
-                        "Filter by color identity (W=White, U=Blue, B=Black, R=Red, G=Green)"
-                    ),
+                    "description": "Color identity filter",
                 },
                 "color_exact": {
                     "type": "boolean",
-                    "description": (
-                        "If true, card must have EXACTLY these colors (for mono-color queries). "
-                        "If false (default), card must have at least one of these colors."
-                    ),
+                    "description": "Require exact color match",
                     "default": False,
                 },
                 "cmc": {
                     "type": "integer",
-                    "description": "Exact mana value (e.g., 3 for 3-drops)",
+                    "description": "Exact mana value",
                 },
                 "cmc_min": {
                     "type": "integer",
@@ -291,19 +248,16 @@ TOOL_DEFINITIONS: list[ToolDefinition] = [
                 "keywords": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": (
-                        "Filter by keyword abilities. Card must have ALL specified keywords. "
-                        "Examples: ['flying'], ['lifelink', 'deathtouch'], ['haste']"
-                    ),
+                    "description": "Required keyword abilities",
                 },
                 "set_code": {
                     "type": "string",
-                    "description": "Filter by set code (e.g., 'DMU', 'FDN', 'OTJ')",
+                    "description": "Set code filter",
                 },
                 "rarity": {
                     "type": "string",
                     "enum": ["common", "uncommon", "rare", "mythic"],
-                    "description": "Filter by rarity",
+                    "description": "Rarity filter",
                 },
                 "format_legal": {
                     "type": "string",
@@ -318,132 +272,99 @@ TOOL_DEFINITIONS: list[ToolDefinition] = [
                         "brawl",
                         "timeless",
                     ],
-                    "description": "Filter by format legality",
+                    "description": "Format legality filter",
                 },
                 "power_min": {
                     "type": "integer",
-                    "description": "Minimum power (creatures only)",
+                    "description": "Min power",
                 },
                 "power_max": {
                     "type": "integer",
-                    "description": "Maximum power (creatures only)",
+                    "description": "Max power",
                 },
                 "toughness_min": {
                     "type": "integer",
-                    "description": "Minimum toughness (creatures only)",
+                    "description": "Min toughness",
                 },
                 "toughness_max": {
                     "type": "integer",
-                    "description": "Maximum toughness (creatures only)",
+                    "description": "Max toughness",
                 },
                 "min_quantity": {
                     "type": "integer",
-                    "description": "Only show cards owned in at least this quantity",
+                    "description": "Min owned quantity",
                     "default": 1,
                 },
             },
-            "required": ["user_id"],
+            "required": [],
         },
     ),
     ToolDefinition(
         name="build_deck",
-        description=(
-            "Build a custom deck from the user's collection around a theme. "
-            "Use when the user asks to build a deck around a card type, creature type, "
-            "or keyword like 'build me a shrine deck' or 'make a goblin deck'. "
-            "This builds a COMPLETE 60-card deck using ONLY cards they own."
-        ),
+        description="Build a 60-card deck from user's collection around a theme.",
         parameters={
             "type": "object",
             "properties": {
-                "user_id": {
-                    "type": "string",
-                    "description": "The user's ID",
-                },
                 "theme": {
                     "type": "string",
-                    "description": (
-                        "Card name, type, or keyword to build around. "
-                        "Examples: 'Shrine', 'Goblin', 'sacrifice', 'graveyard'"
-                    ),
+                    "description": "Theme to build around",
                 },
                 "colors": {
                     "type": "array",
                     "items": {"type": "string", "enum": ["W", "U", "B", "R", "G"]},
-                    "description": (
-                        "Optional color restriction. "
-                        "If not specified, colors are determined from theme cards."
-                    ),
+                    "description": "Color restriction",
                 },
                 "format": {
                     "type": "string",
                     "enum": ["standard", "historic", "explorer", "timeless", "brawl"],
-                    "description": "Format for legality checking",
+                    "description": "Format for legality",
                     "default": "standard",
                 },
                 "include_cards": {
                     "type": "array",
                     "items": {"type": "string"},
-                    "description": "Specific cards that MUST be included in the deck",
+                    "description": "Cards to include",
                 },
             },
-            "required": ["user_id", "theme"],
+            "required": ["theme"],
         },
     ),
     ToolDefinition(
         name="find_synergies",
-        description=(
-            "Find cards in the user's collection that synergize with a specific card. "
-            "Use when the user asks 'what cards work well with X?' or 'find synergies for X'. "
-            "Returns cards that share mechanical synergies like sacrifice, graveyard, tokens, etc."
-        ),
+        description="Find cards that synergize with a specific card.",
         parameters={
             "type": "object",
             "properties": {
-                "user_id": {
-                    "type": "string",
-                    "description": "The user's ID",
-                },
                 "card_name": {
                     "type": "string",
-                    "description": "The card to find synergies for",
+                    "description": "Card to find synergies for",
                 },
                 "max_results": {
                     "type": "integer",
-                    "description": "Maximum number of synergistic cards to return",
+                    "description": "Max results",
                     "default": 20,
                 },
             },
-            "required": ["user_id", "card_name"],
+            "required": ["card_name"],
         },
     ),
     ToolDefinition(
         name="export_to_arena",
-        description=(
-            "Convert a deck to MTG Arena import format. "
-            "Use this AFTER building a deck with build_deck. "
-            "Returns text that can be copy-pasted directly into Arena's import function."
-        ),
+        description="Convert a deck to MTG Arena import format.",
         parameters={
             "type": "object",
             "properties": {
                 "cards": {
                     "type": "object",
-                    "description": (
-                        "The deck's non-land cards as {card_name: quantity}. "
-                        "Get this from the 'cards' field of a build_deck response."
-                    ),
+                    "description": "Non-land cards {name: qty}",
                 },
                 "lands": {
                     "type": "object",
-                    "description": (
-                        "The deck's lands as {land_name: quantity}. "
-                        "Get this from the 'lands' field of a build_deck response."
-                    ),
+                    "description": "Land cards {name: qty}",
                 },
                 "deck_name": {
                     "type": "string",
-                    "description": "Name for the deck (optional)",
+                    "description": "Deck name",
                     "default": "Deck",
                 },
             },
@@ -452,100 +373,67 @@ TOOL_DEFINITIONS: list[ToolDefinition] = [
     ),
     ToolDefinition(
         name="improve_deck",
-        description=(
-            "Analyze an existing deck list and suggest improvements from the user's collection. "
-            "Use when a user pastes a deck list and asks to improve, upgrade, or optimize it. "
-            "Returns card swap suggestions, deck analysis, and general advice."
-        ),
+        description="Suggest improvements to a deck from user's collection.",
         parameters={
             "type": "object",
             "properties": {
-                "user_id": {
-                    "type": "string",
-                    "description": "The user's ID",
-                },
                 "deck_text": {
                     "type": "string",
-                    "description": (
-                        "The deck list in Arena format. "
-                        "Example: '4 Lightning Bolt (STA) 42\\n20 Mountain (FDN) 279'"
-                    ),
+                    "description": "Deck list in Arena format",
                 },
                 "max_suggestions": {
                     "type": "integer",
-                    "description": "Maximum number of card swap suggestions to return",
+                    "description": "Max suggestions",
                     "default": 5,
                 },
             },
-            "required": ["user_id", "deck_text"],
+            "required": ["deck_text"],
         },
     ),
     ToolDefinition(
         name="get_deck_assumptions",
-        description=(
-            "Analyze a deck to surface its implicit assumptions. "
-            "Use when a user asks 'what does this deck rely on?', 'why is my deck inconsistent?', "
-            "'what assumptions does this deck make?', or 'what makes this deck fragile?'. "
-            "Returns mana curve expectations, key card dependencies, draw consistency, "
-            "and interaction timing assumptions with health indicators."
-        ),
+        description="Analyze a deck's implicit assumptions and fragility.",
         parameters={
             "type": "object",
             "properties": {
-                "user_id": {
-                    "type": "string",
-                    "description": "The user's ID",
-                },
                 "format": {
                     "type": "string",
-                    "description": "Game format the deck belongs to",
+                    "description": "Game format",
                 },
                 "deck_name": {
                     "type": "string",
-                    "description": "Name of the meta deck to analyze",
+                    "description": "Deck name",
                 },
             },
-            "required": ["user_id", "format", "deck_name"],
+            "required": ["format", "deck_name"],
         },
     ),
     ToolDefinition(
         name="stress_deck_assumption",
-        description=(
-            "Apply stress to a deck to see how it handles adversity. "
-            "Use when a user asks 'what if I don't draw X?', "
-            "'what happens if my key card is removed?', "
-            "'how does this deck handle mana problems?', or 'stress test this deck'. "
-            "Returns before/after fragility comparison and recommendations."
-        ),
+        description="Apply stress to a deck and measure fragility impact.",
         parameters={
             "type": "object",
             "properties": {
                 "format": {
                     "type": "string",
-                    "description": "Game format the deck belongs to",
+                    "description": "Game format",
                 },
                 "deck_name": {
                     "type": "string",
-                    "description": "Name of the meta deck to stress test",
+                    "description": "Deck name",
                 },
                 "stress_type": {
                     "type": "string",
                     "enum": ["underperform", "missing", "delayed", "hostile_meta"],
-                    "description": (
-                        "Type of stress: underperform (key cards less effective), "
-                        "missing (remove copies of a card), delayed (mana problems), "
-                        "hostile_meta (more opponent interaction)"
-                    ),
+                    "description": "Type of stress",
                 },
                 "target": {
                     "type": "string",
-                    "description": (
-                        "What to stress - a card name for 'missing', or 'all' for general stress"
-                    ),
+                    "description": "Card name or 'all'",
                 },
                 "intensity": {
                     "type": "number",
-                    "description": "Stress intensity from 0.0 (minimal) to 1.0 (maximum)",
+                    "description": "Intensity 0.0-1.0",
                     "default": 0.5,
                 },
             },
@@ -554,22 +442,17 @@ TOOL_DEFINITIONS: list[ToolDefinition] = [
     ),
     ToolDefinition(
         name="find_deck_breaking_point",
-        description=(
-            "Find the weakest point in a deck by testing multiple stress scenarios. "
-            "Use when a user asks 'what breaks first in this deck?', "
-            "'what is my deck's biggest weakness?', or 'how resilient is this deck?'. "
-            "Returns the most vulnerable assumption and overall resilience score."
-        ),
+        description="Find the weakest point in a deck.",
         parameters={
             "type": "object",
             "properties": {
                 "format": {
                     "type": "string",
-                    "description": "Game format the deck belongs to",
+                    "description": "Game format",
                 },
                 "deck_name": {
                     "type": "string",
-                    "description": "Name of the meta deck to analyze",
+                    "description": "Deck name",
                 },
             },
             "required": ["format", "deck_name"],

--- a/tests/test_tool_schema.py
+++ b/tests/test_tool_schema.py
@@ -1,0 +1,249 @@
+"""
+Tests for Tool Schema Invariants (PR 7).
+
+These tests verify:
+1. Tool names are unchanged
+2. Required parameters are unchanged
+3. Removed parameters (user_id) are server-injected
+4. Schema structure remains valid JSON Schema
+"""
+
+import pytest
+
+from forgebreaker.mcp.tools import TOOL_DEFINITIONS, execute_tool
+
+# =============================================================================
+# EXPECTED TOOL NAMES (AUTHORITATIVE - DO NOT CHANGE)
+# =============================================================================
+
+EXPECTED_TOOL_NAMES = [
+    "get_deck_recommendations",
+    "calculate_deck_distance",
+    "get_collection_stats",
+    "list_meta_decks",
+    "search_collection",
+    "build_deck",
+    "find_synergies",
+    "export_to_arena",
+    "improve_deck",
+    "get_deck_assumptions",
+    "stress_deck_assumption",
+    "find_deck_breaking_point",
+]
+
+
+# =============================================================================
+# EXPECTED REQUIRED PARAMETERS (AUTHORITATIVE - DO NOT CHANGE)
+# These are the MODEL-FACING required parameters, not server-injected ones.
+# =============================================================================
+
+EXPECTED_REQUIRED_PARAMS = {
+    "get_deck_recommendations": ["format"],
+    "calculate_deck_distance": ["format", "deck_name"],
+    "get_collection_stats": [],
+    "list_meta_decks": ["format"],
+    "search_collection": [],
+    "build_deck": ["theme"],
+    "find_synergies": ["card_name"],
+    "export_to_arena": ["cards", "lands"],
+    "improve_deck": ["deck_text"],
+    "get_deck_assumptions": ["format", "deck_name"],
+    "stress_deck_assumption": ["format", "deck_name", "stress_type", "target"],
+    "find_deck_breaking_point": ["format", "deck_name"],
+}
+
+
+# =============================================================================
+# SERVER-INJECTED PARAMETERS (REMOVED FROM SCHEMA)
+# =============================================================================
+
+SERVER_INJECTED_PARAMS = ["user_id"]
+
+
+# =============================================================================
+# TOOL NAME TESTS
+# =============================================================================
+
+
+class TestToolNames:
+    """Tests that tool names are unchanged."""
+
+    def test_tool_count_unchanged(self) -> None:
+        """Number of tools matches expected."""
+        assert len(TOOL_DEFINITIONS) == len(EXPECTED_TOOL_NAMES)
+
+    def test_all_expected_tools_present(self) -> None:
+        """All expected tool names are present."""
+        actual_names = [t.name for t in TOOL_DEFINITIONS]
+        for expected_name in EXPECTED_TOOL_NAMES:
+            assert expected_name in actual_names, f"Missing tool: {expected_name}"
+
+    def test_no_unexpected_tools(self) -> None:
+        """No unexpected tools were added."""
+        actual_names = [t.name for t in TOOL_DEFINITIONS]
+        for actual_name in actual_names:
+            assert actual_name in EXPECTED_TOOL_NAMES, f"Unexpected tool: {actual_name}"
+
+    def test_tool_order_preserved(self) -> None:
+        """Tool order matches expected order."""
+        actual_names = [t.name for t in TOOL_DEFINITIONS]
+        assert actual_names == EXPECTED_TOOL_NAMES
+
+
+# =============================================================================
+# REQUIRED PARAMETER TESTS
+# =============================================================================
+
+
+class TestRequiredParameters:
+    """Tests that required parameters are unchanged."""
+
+    @pytest.mark.parametrize("tool_name", EXPECTED_TOOL_NAMES)
+    def test_required_params_match(self, tool_name: str) -> None:
+        """Required parameters match expected for each tool."""
+        tool = next(t for t in TOOL_DEFINITIONS if t.name == tool_name)
+        actual_required = tool.parameters.get("required", [])
+        expected_required = EXPECTED_REQUIRED_PARAMS[tool_name]
+
+        assert set(actual_required) == set(expected_required), (
+            f"Tool '{tool_name}' required params mismatch. "
+            f"Expected: {expected_required}, Got: {actual_required}"
+        )
+
+
+# =============================================================================
+# SERVER-INJECTED PARAMETER TESTS
+# =============================================================================
+
+
+class TestServerInjectedParams:
+    """Tests that server-injected params are removed from schemas."""
+
+    @pytest.mark.parametrize("tool_name", EXPECTED_TOOL_NAMES)
+    def test_user_id_not_in_schema(self, tool_name: str) -> None:
+        """user_id is not in any tool's schema properties."""
+        tool = next(t for t in TOOL_DEFINITIONS if t.name == tool_name)
+        properties = tool.parameters.get("properties", {})
+
+        for server_param in SERVER_INJECTED_PARAMS:
+            assert server_param not in properties, (
+                f"Tool '{tool_name}' should not have '{server_param}' in schema. "
+                "This is a server-injected parameter."
+            )
+
+    @pytest.mark.parametrize("tool_name", EXPECTED_TOOL_NAMES)
+    def test_user_id_not_required(self, tool_name: str) -> None:
+        """user_id is not in any tool's required list."""
+        tool = next(t for t in TOOL_DEFINITIONS if t.name == tool_name)
+        required = tool.parameters.get("required", [])
+
+        for server_param in SERVER_INJECTED_PARAMS:
+            assert server_param not in required, (
+                f"Tool '{tool_name}' should not require '{server_param}'. "
+                "This is a server-injected parameter."
+            )
+
+
+# =============================================================================
+# SCHEMA STRUCTURE TESTS
+# =============================================================================
+
+
+class TestSchemaStructure:
+    """Tests that schemas are valid JSON Schema."""
+
+    @pytest.mark.parametrize("tool_name", EXPECTED_TOOL_NAMES)
+    def test_has_type_object(self, tool_name: str) -> None:
+        """Each tool schema has type: object."""
+        tool = next(t for t in TOOL_DEFINITIONS if t.name == tool_name)
+        assert tool.parameters.get("type") == "object"
+
+    @pytest.mark.parametrize("tool_name", EXPECTED_TOOL_NAMES)
+    def test_has_properties(self, tool_name: str) -> None:
+        """Each tool schema has a properties field."""
+        tool = next(t for t in TOOL_DEFINITIONS if t.name == tool_name)
+        assert "properties" in tool.parameters
+
+    @pytest.mark.parametrize("tool_name", EXPECTED_TOOL_NAMES)
+    def test_has_required(self, tool_name: str) -> None:
+        """Each tool schema has a required field."""
+        tool = next(t for t in TOOL_DEFINITIONS if t.name == tool_name)
+        assert "required" in tool.parameters
+
+    @pytest.mark.parametrize("tool_name", EXPECTED_TOOL_NAMES)
+    def test_description_is_concise(self, tool_name: str) -> None:
+        """Tool descriptions are concise (single sentence, < 100 chars)."""
+        tool = next(t for t in TOOL_DEFINITIONS if t.name == tool_name)
+        description = tool.description
+
+        # Should be a single sentence (one period at end)
+        assert description.endswith("."), f"Tool '{tool_name}' description should end with period"
+        # Remove the final period and check there are no others
+        inner = description[:-1]
+        assert inner.count(".") == 0, (
+            f"Tool '{tool_name}' description should be single sentence: {description}"
+        )
+        # Should be reasonably short
+        assert len(description) < 100, (
+            f"Tool '{tool_name}' description too long ({len(description)} chars): {description}"
+        )
+
+
+# =============================================================================
+# PARAMETER DESCRIPTION TESTS
+# =============================================================================
+
+
+class TestParameterDescriptions:
+    """Tests that parameter descriptions are concise."""
+
+    @pytest.mark.parametrize("tool_name", EXPECTED_TOOL_NAMES)
+    def test_param_descriptions_concise(self, tool_name: str) -> None:
+        """Parameter descriptions are <= 8 words."""
+        tool = next(t for t in TOOL_DEFINITIONS if t.name == tool_name)
+        properties = tool.parameters.get("properties", {})
+
+        for param_name, param_def in properties.items():
+            description = param_def.get("description", "")
+            word_count = len(description.split())
+            assert word_count <= 8, (
+                f"Tool '{tool_name}' param '{param_name}' description too long "
+                f"({word_count} words): '{description}'"
+            )
+
+
+# =============================================================================
+# EXECUTE_TOOL DISPATCH TESTS
+# =============================================================================
+
+
+class TestExecuteToolDispatch:
+    """Tests that execute_tool handles all tools."""
+
+    def test_unknown_tool_raises(self) -> None:
+        """Unknown tool name raises ValueError."""
+        import asyncio
+
+        async def test():
+            from unittest.mock import MagicMock
+
+            mock_session = MagicMock()
+            with pytest.raises(ValueError, match="Unknown tool"):
+                await execute_tool(mock_session, "nonexistent_tool", {})
+
+        asyncio.run(test())
+
+    def test_all_tools_have_handler(self) -> None:
+        """All defined tools have a handler in execute_tool."""
+        import inspect
+
+        from forgebreaker.mcp import tools as tools_module
+
+        # Get the source of execute_tool
+        source = inspect.getsource(tools_module.execute_tool)
+
+        for tool_name in EXPECTED_TOOL_NAMES:
+            # Check that the tool name appears in the dispatch logic
+            assert f'"{tool_name}"' in source or f"'{tool_name}'" in source, (
+                f"Tool '{tool_name}' not handled in execute_tool"
+            )


### PR DESCRIPTION
## Summary

Reduces tool schema verbosity to cut token overhead without changing behavior.

**Before:** ~4,000+ tokens of schema text per LLM request
**After:** ~1,600 tokens of schema text (~60% reduction)

## Changes

### Schema Changes (tools.py)

| Change | Description |
|--------|-------------|
| Remove `user_id` | Server-injected parameter removed from all 8 affected tool schemas |
| Shorten descriptions | All tool descriptions reduced to single sentences |
| Prune param descriptions | All parameter descriptions reduced to ≤8 words |

### Tests (test_tool_schema.py)

102 new tests verifying:
- Tool names unchanged (4 tests)
- Required parameters unchanged (12 tests)  
- `user_id` not in any schema (24 tests)
- Schema structure valid (48 tests)
- Parameter descriptions concise (12 tests)
- Execute tool dispatch handles all tools (2 tests)

## What Did NOT Change

- Tool names
- Tool behavior
- Required parameters (model-facing)
- Return shapes
- Tool order

## Test Plan

- [x] `ruff format --check .` passes
- [x] `ruff check .` passes
- [x] `mypy forgebreaker` passes (pre-existing ML warnings only)
- [x] `pytest` passes (910 tests, 81.45% coverage)
- [x] Schema snapshot tests verify invariants

🤖 Generated with [Claude Code](https://claude.com/claude-code)