### PR TITLE
fix(budget): raise LLM call limit from 3 to 5 for agentic tool-use

### DIFF
--- a/forgebreaker/api/chat.py
+++ b/forgebreaker/api/chat.py
@@ -195,8 +195,9 @@ Use when users want to know what works together:
 - "Find synergies for my sacrifice deck"
 
 ### export_to_arena
-Use AFTER building a deck to give the user importable text.
-Takes the cards and lands from a previous build_deck call.
+Convert a deck to MTG Arena import format.
+NOTE: build_deck already includes arena_export in its response.
+Only use this tool if the user provides a custom card list to export.
 
 ### improve_deck
 Use when users paste an existing deck list and ask to improve or upgrade it:
@@ -230,7 +231,7 @@ Use to show collection overview (total cards, unique cards):
 
 1. ALWAYS use tools - don't guess about the user's collection
 2. When building casual decks, use build_deck - don't suggest meta decks
-3. After building a deck, offer to export it for Arena
+3. build_deck includes Arena export automatically - show it directly, don't call export_to_arena
 4. If a theme has no cards, say so clearly
 5. Be encouraging about casual/fun decks - not everything needs to be competitive
 
@@ -240,7 +241,7 @@ User: "Build me a shrine deck"
 
 1. Call build_deck(theme="shrine") to create the deck using only cards they own
 2. Show the deck with explanations
-3. Offer: "Would you like me to export this for Arena import?"
+3. The response includes arena_export - show it directly so user can copy/paste to Arena
 
 (Optional) If the user first wants to see what shrines they own, you MAY call
 search_collection(name_contains="shrine") before building the deck.

--- a/forgebreaker/models/budget.py
+++ b/forgebreaker/models/budget.py
@@ -25,7 +25,12 @@ from forgebreaker.models.failure import FailureKind, KnownError
 # HARD LIMITS (Constants — NOT Configurable)
 # =============================================================================
 
-MAX_LLM_CALLS_PER_REQUEST = 3
+# Budget for agentic tool-use loop:
+# - Single tool use = 2 calls (invoke + process result)
+# - Two chained tools = 3 calls
+# - Tool + clarification + tool = 4 calls
+# - Buffer for edge cases = 5 calls
+MAX_LLM_CALLS_PER_REQUEST = 5
 MAX_TOKENS_PER_REQUEST = 20_000
 
 

--- a/tests/test_terminal_outcomes.py
+++ b/tests/test_terminal_outcomes.py
@@ -248,14 +248,15 @@ class TestSingleShotSuccess:
         """
         Contract: MAX_LLM_CALLS_PER_REQUEST allows success but prevents loops.
 
-        For a simple request:
-        - LLM call 1: Claude sees request, calls tool
-        - LLM call 2: Claude receives result, formats response
-        - LLM call 3: Buffer for edge cases
+        Budget for agentic tool-use loop:
+        - Single tool use = 2 calls (invoke + process result)
+        - Two chained tools = 3 calls
+        - Tool + clarification + tool = 4 calls
+        - Buffer for edge cases = 5 calls
 
-        3 calls should be sufficient for any single-intent request.
+        5 calls allows reasonable tool chains while preventing runaway loops.
         """
-        assert MAX_LLM_CALLS_PER_REQUEST == 3
+        assert MAX_LLM_CALLS_PER_REQUEST == 5
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Raise MAX_LLM_CALLS_PER_REQUEST from 3 to 5 for agentic tool-use patterns
- Include arena_export directly in build_deck response to eliminate follow-up tool call
- Update system prompt to reflect new behavior

## Problem

`MAX_LLM_CALLS_PER_REQUEST = 3` is too low for agentic tool-use patterns. A single tool use requires 2 LLM calls minimum (invoke + process result), leaving only 1 call for any follow-up work.

## Solution

### Part 1: Include Arena Export in build_deck Response
Added `arena_export` field to `build_deck_tool` response so users get the Arena-importable deck format without needing a separate `export_to_arena` call.

### Part 2: Raise Budget from 3 to 5
Budget rationale:
- Single tool use = 2 calls (invoke + process result)
- Two chained tools = 3 calls
- Tool + clarification + tool = 4 calls
- Buffer for edge cases = 5 calls

## Files Changed

| File | Change |
|------|--------|
| `forgebreaker/models/budget.py` | Constant from 3 to 5 |
| `forgebreaker/mcp/tools.py` | Add arena_export to build_deck response |
| `forgebreaker/api/chat.py` | Update system prompt |
| `tests/test_budget.py` | Tests for new budget value |
| `tests/test_mcp_tools.py` | Test for arena_export field |
| `tests/test_terminal_outcomes.py` | Update contract test |

## Test Plan

- [x] `ruff format --check .` passes
- [x] `ruff check .` passes
- [x] `mypy forgebreaker` passes (existing ML warnings only)
- [x] `pytest` passes (1001 tests, 84% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)