### PR TITLE
fix(chat): refine terminal success detection for empty results

### DIFF
--- a/tests/test_api_chat.py
+++ b/tests/test_api_chat.py
@@ -336,14 +336,33 @@ class TestTerminalSuccessInvariant:
         """_is_terminal_success correctly identifies successful tool results."""
         from forgebreaker.api.chat import _is_terminal_success
 
-        # build_deck with success=True is terminal
-        assert _is_terminal_success("build_deck", {"success": True, "deck_name": "Test"})
+        # build_deck with success=True AND cards is terminal
+        assert _is_terminal_success(
+            "build_deck",
+            {"success": True, "deck_name": "Test", "total_cards": 60, "cards": {"Goblin": 4}},
+        )
+
+        # build_deck with 0 cards is NOT terminal (empty result)
+        assert not _is_terminal_success(
+            "build_deck", {"success": True, "deck_name": "Test", "total_cards": 0, "cards": {}}
+        )
 
         # build_deck with error is NOT terminal success
         assert not _is_terminal_success("build_deck", {"error": "No cards found"})
 
+        # build_deck with "no cards" warning is NOT terminal
+        assert not _is_terminal_success(
+            "build_deck",
+            {"success": True, "total_cards": 0, "warnings": ["No cards matching theme found"]},
+        )
+
         # search_collection with results is terminal
-        assert _is_terminal_success("search_collection", {"results": [], "total": 0})
+        assert _is_terminal_success(
+            "search_collection", {"results": [{"name": "Card"}], "total": 1}
+        )
+
+        # search_collection with empty results is NOT terminal
+        assert not _is_terminal_success("search_collection", {"results": [], "total": 0})
 
         # Unknown tool is NOT terminal
         assert not _is_terminal_success("unknown_tool", {"success": True})


### PR DESCRIPTION
## Summary

Fixes the terminal success detection to NOT mark empty results as success.

When a user asks "build me a goblin deck" but no goblins are found, the tool returns `success: true` with `total_cards: 0`. Previously, this was marked as terminal success and immediately formatted - producing an empty deck response.

Now, empty results allow the LLM to continue and explain or retry.

## Changes

| Condition | Before | After |
|-----------|--------|-------|
| `build_deck` with 0 cards | Terminal SUCCESS | NOT terminal |
| `search_collection` with 0 results | Terminal SUCCESS | NOT terminal |
| Warnings containing "no cards" | Terminal SUCCESS | NOT terminal |

## Behavior

**Valid results (terminal success → 1 LLM call):**
- build_deck returns 60 cards
- search_collection returns 5 matches

**Empty results (NOT terminal → LLM continues):**
- build_deck returns 0 cards with warning
- search_collection returns [] results

## Test Plan

- [x] `ruff check .` passes
- [x] `pytest` passes (1203 tests, 83.70% coverage)
- [x] `test_empty_result_is_not_terminal_success` - NEW
- [x] Updated `test_terminal_success_detection`

🤖 Generated with [Claude Code](https://claude.com/claude-code)