### PR TITLE
feat(services): add cost controls for rate limiting and daily budgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,52 @@ ForgeBreaker simulates these scenarios and shows you the before/after fragility 
 
 ---
 
+## Usage Limits & Cost Controls
+
+ForgeBreaker is a **demo/portfolio project**. To prevent abuse and control LLM costs, the following limits are enforced:
+
+### Per-User Rate Limits
+
+| Limit | Default | Description |
+|-------|---------|-------------|
+| Requests per IP per day | 20 | Each IP address gets 20 chat requests per day |
+
+When you exceed the rate limit, you'll receive an HTTP 429 response with a friendly message explaining the limit resets at midnight UTC.
+
+### Global Daily Budgets
+
+| Limit | Default | Description |
+|-------|---------|-------------|
+| LLM calls per day | 500 | Total Claude API calls across all users |
+| Tokens per day | 500,000 | Total tokens (input + output) across all users |
+
+These are **hard caps**. When exceeded, the service returns HTTP 503 until the next day.
+
+### Emergency Kill Switch
+
+The `LLM_ENABLED` environment variable can be set to `false` to immediately disable all LLM functionality without redeploying. This is useful for:
+- Cost emergencies
+- Maintenance windows
+- API key rotation
+
+### Monitoring
+
+The `/diagnostics/usage-stats` endpoint shows current usage:
+- Unique IPs today
+- LLM calls made / remaining
+- Tokens used / remaining
+- Current limits
+
+### Why These Limits Exist
+
+1. **Cost control**: Claude API calls cost money. These limits prevent unexpected bills.
+2. **Fair access**: Per-IP limits ensure one user can't monopolize the service.
+3. **Demo appropriate**: This is a portfolio project, not a production service.
+
+If you're interested in running ForgeBreaker without limits, you can self-host with your own API key.
+
+---
+
 ## Technical Details
 
 ### Tech Stack
@@ -158,6 +204,10 @@ npm run dev
 |----------|-------------|
 | `DATABASE_URL` | PostgreSQL connection string |
 | `ANTHROPIC_API_KEY` | Claude API key (for chat) |
+| `LLM_ENABLED` | Kill switch for LLM (default: `true`) |
+| `REQUESTS_PER_IP_PER_DAY` | Per-IP rate limit (default: `20`) |
+| `MAX_LLM_CALLS_PER_DAY` | Global daily LLM call limit (default: `500`) |
+| `MAX_TOKENS_PER_DAY` | Global daily token limit (default: `500000`) |
 
 ---
 

--- a/forgebreaker/config.py
+++ b/forgebreaker/config.py
@@ -20,6 +20,23 @@ class Settings(BaseSettings):
     # Default: True (filtered pool enabled, explicit opt-out available)
     use_filtered_candidate_pool: bool = True
 
+    # ==========================================================================
+    # COST CONTROLS (PR 105)
+    # This is a demo project. These limits protect against abuse and cost overruns.
+    # ==========================================================================
+
+    # Kill switch: Set to false to disable all LLM functionality
+    llm_enabled: bool = True
+
+    # Per-IP rate limit (requests per day)
+    # Demo users get 20 requests per day per IP address
+    requests_per_ip_per_day: int = 20
+
+    # Global daily LLM budget (hard caps)
+    # These limits apply across ALL users combined
+    max_llm_calls_per_day: int = 500
+    max_tokens_per_day: int = 500_000
+
 
 settings = Settings()
 

--- a/forgebreaker/services/__init__.py
+++ b/forgebreaker/services/__init__.py
@@ -71,6 +71,16 @@ from forgebreaker.services.collection_search import (
     format_search_results,
     search_collection,
 )
+from forgebreaker.services.cost_controls import (
+    DailyBudgetExceededError,
+    DailyUsageTracker,
+    LLMDisabledError,
+    RateLimitExceededError,
+    check_llm_enabled,
+    enforce_cost_controls,
+    get_usage_tracker,
+    reset_usage_tracker,
+)
 from forgebreaker.services.deck_builder import (
     BuiltDeck,
     DeckBuildRequest,
@@ -175,4 +185,13 @@ __all__ = [
     "record_clarification",
     "resolve_intent_with_policy",
     "should_ask_clarification",
+    # Cost controls
+    "DailyBudgetExceededError",
+    "DailyUsageTracker",
+    "LLMDisabledError",
+    "RateLimitExceededError",
+    "check_llm_enabled",
+    "enforce_cost_controls",
+    "get_usage_tracker",
+    "reset_usage_tracker",
 ]

--- a/forgebreaker/services/cost_controls.py
+++ b/forgebreaker/services/cost_controls.py
@@ -1,0 +1,357 @@
+"""
+Cost Controls — Rate Limiting and Daily Budget Enforcement.
+
+This module protects ForgeBreaker (a demo/portfolio project) from:
+- Abuse via excessive requests from a single IP
+- Unexpected LLM costs via daily budget caps
+- Runaway costs via environment-level kill switch
+
+INVARIANTS:
+- All limits are HARD CAPS, not soft limits
+- Exceedance is TERMINAL — no retries, no fallback
+- Limits are enforced BEFORE any LLM logic runs
+- IP-based limits use hashed IPs for privacy in logs
+
+ENFORCEMENT:
+- Per-IP: 20 requests per day per IP address
+- Global: Configurable daily LLM calls and tokens
+- Kill switch: LLM_ENABLED environment variable
+"""
+
+import hashlib
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime
+from threading import Lock
+
+from forgebreaker.models.failure import FailureKind, KnownError
+
+logger = logging.getLogger(__name__)
+
+# =============================================================================
+# CONFIGURATION DEFAULTS
+# =============================================================================
+
+# Per-IP rate limit (requests per day)
+DEFAULT_REQUESTS_PER_IP_PER_DAY = 20
+
+# Global daily limits
+DEFAULT_MAX_LLM_CALLS_PER_DAY = 500
+DEFAULT_MAX_TOKENS_PER_DAY = 500_000
+
+
+# =============================================================================
+# CUSTOM EXCEPTIONS
+# =============================================================================
+
+
+class RateLimitExceededError(KnownError):
+    """
+    Exception raised when per-IP rate limit is exceeded.
+
+    Returns HTTP 429 with a clear demo message.
+    """
+
+    def __init__(self, ip_hash: str, limit: int):
+        self.ip_hash = ip_hash
+        self.limit = limit
+        super().__init__(
+            kind=FailureKind.BUDGET_EXCEEDED,
+            message=(
+                "This is a demo project with limited usage. "
+                f"You've reached today's request limit ({limit}). "
+                "Please try again tomorrow."
+            ),
+            detail=f"IP rate limit: {limit}/day",
+            suggestion="This limit resets at midnight UTC.",
+            status_code=429,
+        )
+
+
+class DailyBudgetExceededError(KnownError):
+    """
+    Exception raised when global daily LLM budget is exceeded.
+
+    This is a hard failure with no retries.
+    """
+
+    def __init__(self, limit_type: str, used: int, limit: int):
+        self.limit_type = limit_type
+        self.used = used
+        self.limit = limit
+        super().__init__(
+            kind=FailureKind.BUDGET_EXCEEDED,
+            message=(
+                "This demo project has reached its daily usage limit. "
+                "Service will resume tomorrow. Thank you for your interest!"
+            ),
+            detail=f"Daily {limit_type}: {used}/{limit}",
+            suggestion="This limit resets at midnight UTC.",
+            status_code=503,
+        )
+
+
+class LLMDisabledError(KnownError):
+    """
+    Exception raised when LLM is disabled via environment.
+
+    This is an immediate failure with no partial execution.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(
+            kind=FailureKind.SERVICE_UNAVAILABLE,
+            message="LLM functionality is currently disabled.",
+            detail="LLM_ENABLED=false",
+            suggestion="This is intentional. The service may be in maintenance mode.",
+            status_code=503,
+        )
+
+
+# =============================================================================
+# THREAD-SAFE USAGE TRACKER
+# =============================================================================
+
+
+@dataclass
+class DailyUsageTracker:
+    """
+    Thread-safe tracker for daily usage limits.
+
+    Resets automatically at midnight UTC.
+
+    Tracks:
+    - Per-IP request counts (for rate limiting)
+    - Global LLM call count (for cost control)
+    - Global token count (for cost control)
+    """
+
+    # Configuration
+    requests_per_ip_per_day: int = DEFAULT_REQUESTS_PER_IP_PER_DAY
+    max_llm_calls_per_day: int = DEFAULT_MAX_LLM_CALLS_PER_DAY
+    max_tokens_per_day: int = DEFAULT_MAX_TOKENS_PER_DAY
+
+    # State
+    _current_date: date = field(default_factory=lambda: datetime.now(UTC).date())
+    _ip_request_counts: dict[str, int] = field(default_factory=dict)
+    _llm_calls_today: int = 0
+    _tokens_today: int = 0
+    _lock: Lock = field(default_factory=Lock)
+
+    def _maybe_reset(self) -> None:
+        """Reset counters if we've crossed into a new day (UTC)."""
+        today = datetime.now(UTC).date()
+        if today != self._current_date:
+            self._current_date = today
+            self._ip_request_counts.clear()
+            self._llm_calls_today = 0
+            self._tokens_today = 0
+            logger.info(
+                "DAILY_COUNTERS_RESET",
+                extra={"new_date": today.isoformat()},
+            )
+
+    def hash_ip(self, ip_address: str) -> str:
+        """
+        Hash an IP address for privacy-safe logging.
+
+        Uses SHA-256 truncated to 12 characters.
+        """
+        return hashlib.sha256(ip_address.encode()).hexdigest()[:12]
+
+    def check_ip_rate_limit(self, ip_address: str) -> None:
+        """
+        Check and increment per-IP rate limit.
+
+        MUST be called BEFORE any LLM logic runs.
+
+        Raises:
+            RateLimitExceededError: If daily limit exceeded for this IP
+        """
+        with self._lock:
+            self._maybe_reset()
+
+            ip_hash = self.hash_ip(ip_address)
+            current_count = self._ip_request_counts.get(ip_hash, 0)
+
+            if current_count >= self.requests_per_ip_per_day:
+                logger.warning(
+                    "RATE_LIMIT_EXCEEDED",
+                    extra={
+                        "ip_hash": ip_hash,
+                        "requests_today": current_count,
+                        "limit": self.requests_per_ip_per_day,
+                    },
+                )
+                raise RateLimitExceededError(ip_hash, self.requests_per_ip_per_day)
+
+            # Increment count
+            self._ip_request_counts[ip_hash] = current_count + 1
+
+    def check_daily_budget(self) -> None:
+        """
+        Check if global daily LLM budget is available.
+
+        MUST be called BEFORE any LLM call.
+
+        Raises:
+            DailyBudgetExceededError: If daily limit exceeded
+        """
+        with self._lock:
+            self._maybe_reset()
+
+            if self._llm_calls_today >= self.max_llm_calls_per_day:
+                logger.warning(
+                    "DAILY_LLM_BUDGET_EXCEEDED",
+                    extra={
+                        "llm_calls_today": self._llm_calls_today,
+                        "limit": self.max_llm_calls_per_day,
+                    },
+                )
+                raise DailyBudgetExceededError(
+                    limit_type="LLM calls",
+                    used=self._llm_calls_today,
+                    limit=self.max_llm_calls_per_day,
+                )
+
+            if self._tokens_today >= self.max_tokens_per_day:
+                logger.warning(
+                    "DAILY_TOKEN_BUDGET_EXCEEDED",
+                    extra={
+                        "tokens_today": self._tokens_today,
+                        "limit": self.max_tokens_per_day,
+                    },
+                )
+                raise DailyBudgetExceededError(
+                    limit_type="tokens",
+                    used=self._tokens_today,
+                    limit=self.max_tokens_per_day,
+                )
+
+    def record_llm_call(self, input_tokens: int, output_tokens: int) -> None:
+        """
+        Record an LLM call and its token usage.
+
+        MUST be called AFTER each LLM invocation.
+
+        Args:
+            input_tokens: Tokens used in the request
+            output_tokens: Tokens used in the response
+        """
+        with self._lock:
+            self._maybe_reset()
+            self._llm_calls_today += 1
+            self._tokens_today += input_tokens + output_tokens
+
+            logger.debug(
+                "LLM_CALL_RECORDED",
+                extra={
+                    "llm_calls_today": self._llm_calls_today,
+                    "tokens_today": self._tokens_today,
+                },
+            )
+
+    def get_diagnostics(self) -> dict[str, int | str]:
+        """
+        Get current usage diagnostics.
+
+        Returns:
+            Dict with current usage and remaining budget.
+        """
+        with self._lock:
+            self._maybe_reset()
+            return {
+                "date": self._current_date.isoformat(),
+                "unique_ips_today": len(self._ip_request_counts),
+                "llm_calls_today": self._llm_calls_today,
+                "llm_calls_remaining": max(0, self.max_llm_calls_per_day - self._llm_calls_today),
+                "tokens_today": self._tokens_today,
+                "tokens_remaining": max(0, self.max_tokens_per_day - self._tokens_today),
+                "requests_per_ip_limit": self.requests_per_ip_per_day,
+                "llm_calls_limit": self.max_llm_calls_per_day,
+                "tokens_limit": self.max_tokens_per_day,
+            }
+
+
+# =============================================================================
+# GLOBAL TRACKER INSTANCE
+# =============================================================================
+
+# Singleton tracker instance
+_usage_tracker: DailyUsageTracker | None = None
+
+
+def get_usage_tracker() -> DailyUsageTracker:
+    """Get the global usage tracker instance."""
+    global _usage_tracker
+    if _usage_tracker is None:
+        _usage_tracker = DailyUsageTracker()
+    return _usage_tracker
+
+
+def reset_usage_tracker() -> None:
+    """Reset the global usage tracker (for testing)."""
+    global _usage_tracker
+    _usage_tracker = None
+
+
+# =============================================================================
+# LLM KILL SWITCH
+# =============================================================================
+
+
+def check_llm_enabled(llm_enabled: bool) -> None:
+    """
+    Check if LLM is enabled.
+
+    MUST be called BEFORE any LLM logic runs.
+
+    Args:
+        llm_enabled: Value of LLM_ENABLED setting
+
+    Raises:
+        LLMDisabledError: If LLM is disabled
+    """
+    if not llm_enabled:
+        logger.warning("LLM_DISABLED", extra={"llm_enabled": False})
+        raise LLMDisabledError()
+
+
+# =============================================================================
+# COMBINED GUARD FUNCTION
+# =============================================================================
+
+
+def enforce_cost_controls(
+    ip_address: str,
+    llm_enabled: bool,
+) -> None:
+    """
+    Enforce all cost controls before LLM execution.
+
+    This is the single entry point for all cost control checks.
+    Call this at the start of any LLM-invoking endpoint.
+
+    Order of checks:
+    1. LLM kill switch (fastest, no state)
+    2. IP rate limit (per-request, quick)
+    3. Daily budget (global, quick)
+
+    Args:
+        ip_address: Client IP address
+        llm_enabled: Value of LLM_ENABLED setting
+
+    Raises:
+        LLMDisabledError: If LLM is disabled
+        RateLimitExceededError: If IP rate limit exceeded
+        DailyBudgetExceededError: If daily budget exceeded
+    """
+    # 1. Kill switch (fastest check)
+    check_llm_enabled(llm_enabled)
+
+    # 2. IP rate limit
+    tracker = get_usage_tracker()
+    tracker.check_ip_rate_limit(ip_address)
+
+    # 3. Daily budget
+    tracker.check_daily_budget()

--- a/tests/test_cost_controls.py
+++ b/tests/test_cost_controls.py
@@ -1,0 +1,338 @@
+"""
+Tests for cost controls — rate limiting and daily budget enforcement.
+
+INVARIANTS:
+- All limits are HARD CAPS, not soft limits
+- Exceedance is TERMINAL — no retries, no fallback
+- Limits are enforced BEFORE any LLM logic runs
+- IP-based limits use hashed IPs for privacy in logs
+"""
+
+import pytest
+
+from forgebreaker.models.failure import FailureKind
+from forgebreaker.services.cost_controls import (
+    DailyBudgetExceededError,
+    DailyUsageTracker,
+    LLMDisabledError,
+    RateLimitExceededError,
+    check_llm_enabled,
+    enforce_cost_controls,
+    get_usage_tracker,
+    reset_usage_tracker,
+)
+
+
+class TestRateLimitEnforcement:
+    """Tests for per-IP rate limiting."""
+
+    def setup_method(self) -> None:
+        """Reset global tracker before each test."""
+        reset_usage_tracker()
+
+    def test_first_request_allowed(self) -> None:
+        """First request from an IP is allowed."""
+        tracker = DailyUsageTracker(requests_per_ip_per_day=20)
+        # Should not raise
+        tracker.check_ip_rate_limit("192.168.1.1")
+
+    def test_requests_up_to_limit_allowed(self) -> None:
+        """Requests up to the limit are allowed."""
+        tracker = DailyUsageTracker(requests_per_ip_per_day=5)
+        for _ in range(5):
+            tracker.check_ip_rate_limit("192.168.1.1")
+        # All 5 should succeed
+
+    def test_request_over_limit_raises(self) -> None:
+        """Request over the limit raises RateLimitExceededError."""
+        tracker = DailyUsageTracker(requests_per_ip_per_day=3)
+
+        # Use up the limit
+        for _ in range(3):
+            tracker.check_ip_rate_limit("192.168.1.1")
+
+        # 4th request should fail
+        with pytest.raises(RateLimitExceededError) as exc_info:
+            tracker.check_ip_rate_limit("192.168.1.1")
+
+        error = exc_info.value
+        assert error.limit == 3
+        assert error.status_code == 429
+        assert error.kind == FailureKind.BUDGET_EXCEEDED
+        assert "demo project" in error.message.lower()
+
+    def test_different_ips_have_separate_limits(self) -> None:
+        """Different IPs have separate rate limits."""
+        tracker = DailyUsageTracker(requests_per_ip_per_day=2)
+
+        # IP 1 uses its limit
+        tracker.check_ip_rate_limit("192.168.1.1")
+        tracker.check_ip_rate_limit("192.168.1.1")
+
+        # IP 2 should still be allowed
+        tracker.check_ip_rate_limit("192.168.1.2")
+        tracker.check_ip_rate_limit("192.168.1.2")
+
+        # IP 1 is now blocked
+        with pytest.raises(RateLimitExceededError):
+            tracker.check_ip_rate_limit("192.168.1.1")
+
+        # IP 2 is now blocked
+        with pytest.raises(RateLimitExceededError):
+            tracker.check_ip_rate_limit("192.168.1.2")
+
+    def test_ip_hash_is_deterministic(self) -> None:
+        """Same IP produces same hash."""
+        tracker = DailyUsageTracker()
+        hash1 = tracker.hash_ip("192.168.1.1")
+        hash2 = tracker.hash_ip("192.168.1.1")
+        assert hash1 == hash2
+
+    def test_ip_hash_is_12_chars(self) -> None:
+        """IP hash is truncated to 12 characters."""
+        tracker = DailyUsageTracker()
+        ip_hash = tracker.hash_ip("192.168.1.1")
+        assert len(ip_hash) == 12
+
+    def test_different_ips_produce_different_hashes(self) -> None:
+        """Different IPs produce different hashes."""
+        tracker = DailyUsageTracker()
+        hash1 = tracker.hash_ip("192.168.1.1")
+        hash2 = tracker.hash_ip("192.168.1.2")
+        assert hash1 != hash2
+
+
+class TestDailyBudgetEnforcement:
+    """Tests for global daily LLM budget."""
+
+    def setup_method(self) -> None:
+        """Reset global tracker before each test."""
+        reset_usage_tracker()
+
+    def test_first_call_allowed(self) -> None:
+        """First LLM call is allowed."""
+        tracker = DailyUsageTracker(max_llm_calls_per_day=100)
+        # Should not raise
+        tracker.check_daily_budget()
+
+    def test_calls_up_to_limit_allowed(self) -> None:
+        """LLM calls up to the limit are allowed."""
+        tracker = DailyUsageTracker(max_llm_calls_per_day=3, max_tokens_per_day=100000)
+
+        for _ in range(3):
+            tracker.check_daily_budget()
+            tracker.record_llm_call(100, 100)
+
+    def test_call_over_limit_raises(self) -> None:
+        """LLM call over the limit raises DailyBudgetExceededError."""
+        tracker = DailyUsageTracker(max_llm_calls_per_day=2, max_tokens_per_day=100000)
+
+        # Use up the limit
+        tracker.check_daily_budget()
+        tracker.record_llm_call(100, 100)
+        tracker.check_daily_budget()
+        tracker.record_llm_call(100, 100)
+
+        # 3rd call should fail
+        with pytest.raises(DailyBudgetExceededError) as exc_info:
+            tracker.check_daily_budget()
+
+        error = exc_info.value
+        assert error.limit_type == "LLM calls"
+        assert error.used == 2
+        assert error.limit == 2
+        assert error.status_code == 503
+        assert "demo project" in error.message.lower()
+
+    def test_token_limit_enforced(self) -> None:
+        """Token limit is enforced."""
+        tracker = DailyUsageTracker(max_llm_calls_per_day=100, max_tokens_per_day=1000)
+
+        # Use up tokens
+        tracker.check_daily_budget()
+        tracker.record_llm_call(500, 500)  # 1000 tokens total
+
+        # Next call should fail
+        with pytest.raises(DailyBudgetExceededError) as exc_info:
+            tracker.check_daily_budget()
+
+        error = exc_info.value
+        assert error.limit_type == "tokens"
+        assert error.used == 1000
+        assert error.limit == 1000
+
+    def test_record_llm_call_tracks_usage(self) -> None:
+        """record_llm_call correctly tracks token usage."""
+        tracker = DailyUsageTracker()
+
+        tracker.record_llm_call(100, 50)
+        tracker.record_llm_call(200, 100)
+
+        diagnostics = tracker.get_diagnostics()
+        assert diagnostics["llm_calls_today"] == 2
+        assert diagnostics["tokens_today"] == 450  # 100+50+200+100
+
+
+class TestLLMKillSwitch:
+    """Tests for LLM_ENABLED kill switch."""
+
+    def test_llm_enabled_true_allows_calls(self) -> None:
+        """When LLM is enabled, calls are allowed."""
+        # Should not raise
+        check_llm_enabled(True)
+
+    def test_llm_enabled_false_raises(self) -> None:
+        """When LLM is disabled, LLMDisabledError is raised."""
+        with pytest.raises(LLMDisabledError) as exc_info:
+            check_llm_enabled(False)
+
+        error = exc_info.value
+        assert error.status_code == 503
+        assert error.kind == FailureKind.SERVICE_UNAVAILABLE
+        assert "disabled" in error.message.lower()
+
+
+class TestEnforceCostControls:
+    """Tests for the combined enforce_cost_controls function."""
+
+    def setup_method(self) -> None:
+        """Reset global tracker before each test."""
+        reset_usage_tracker()
+
+    def test_all_checks_pass(self) -> None:
+        """When all checks pass, no exception is raised."""
+        # Should not raise
+        enforce_cost_controls("192.168.1.1", llm_enabled=True)
+
+    def test_kill_switch_checked_first(self) -> None:
+        """Kill switch is checked before rate limit."""
+        # Even if we haven't hit rate limit, kill switch fails first
+        with pytest.raises(LLMDisabledError):
+            enforce_cost_controls("192.168.1.1", llm_enabled=False)
+
+    def test_rate_limit_checked_second(self) -> None:
+        """Rate limit is checked after kill switch."""
+        tracker = get_usage_tracker()
+        tracker.requests_per_ip_per_day = 1
+
+        # First request succeeds
+        enforce_cost_controls("192.168.1.1", llm_enabled=True)
+
+        # Second request fails with rate limit (not kill switch)
+        with pytest.raises(RateLimitExceededError):
+            enforce_cost_controls("192.168.1.1", llm_enabled=True)
+
+    def test_budget_checked_last(self) -> None:
+        """Daily budget is checked after rate limit."""
+        tracker = get_usage_tracker()
+        tracker.max_llm_calls_per_day = 1
+
+        # Record a call to exhaust budget
+        tracker.record_llm_call(100, 100)
+
+        # Budget check should fail (not rate limit)
+        with pytest.raises(DailyBudgetExceededError):
+            enforce_cost_controls("192.168.1.1", llm_enabled=True)
+
+
+class TestDiagnostics:
+    """Tests for usage diagnostics."""
+
+    def setup_method(self) -> None:
+        """Reset global tracker before each test."""
+        reset_usage_tracker()
+
+    def test_diagnostics_returns_all_fields(self) -> None:
+        """Diagnostics returns all expected fields."""
+        tracker = DailyUsageTracker()
+        diagnostics = tracker.get_diagnostics()
+
+        assert "date" in diagnostics
+        assert "unique_ips_today" in diagnostics
+        assert "llm_calls_today" in diagnostics
+        assert "llm_calls_remaining" in diagnostics
+        assert "tokens_today" in diagnostics
+        assert "tokens_remaining" in diagnostics
+        assert "requests_per_ip_limit" in diagnostics
+        assert "llm_calls_limit" in diagnostics
+        assert "tokens_limit" in diagnostics
+
+    def test_diagnostics_tracks_unique_ips(self) -> None:
+        """Diagnostics correctly tracks unique IPs."""
+        tracker = DailyUsageTracker()
+
+        tracker.check_ip_rate_limit("192.168.1.1")
+        tracker.check_ip_rate_limit("192.168.1.2")
+        tracker.check_ip_rate_limit("192.168.1.1")  # Repeat
+
+        diagnostics = tracker.get_diagnostics()
+        assert diagnostics["unique_ips_today"] == 2
+
+    def test_diagnostics_shows_remaining_budget(self) -> None:
+        """Diagnostics shows correct remaining budget."""
+        tracker = DailyUsageTracker(max_llm_calls_per_day=10, max_tokens_per_day=10000)
+
+        tracker.record_llm_call(100, 100)  # 200 tokens
+        tracker.record_llm_call(100, 100)  # 400 tokens total
+
+        diagnostics = tracker.get_diagnostics()
+        assert diagnostics["llm_calls_today"] == 2
+        assert diagnostics["llm_calls_remaining"] == 8
+        assert diagnostics["tokens_today"] == 400
+        assert diagnostics["tokens_remaining"] == 9600
+
+
+class TestGlobalTrackerSingleton:
+    """Tests for global tracker singleton behavior."""
+
+    def setup_method(self) -> None:
+        """Reset global tracker before each test."""
+        reset_usage_tracker()
+
+    def test_get_usage_tracker_returns_singleton(self) -> None:
+        """get_usage_tracker returns the same instance."""
+        tracker1 = get_usage_tracker()
+        tracker2 = get_usage_tracker()
+        assert tracker1 is tracker2
+
+    def test_reset_usage_tracker_clears_singleton(self) -> None:
+        """reset_usage_tracker clears the singleton."""
+        tracker1 = get_usage_tracker()
+        reset_usage_tracker()
+        tracker2 = get_usage_tracker()
+        assert tracker1 is not tracker2
+
+    def test_state_persists_across_calls(self) -> None:
+        """State persists when using get_usage_tracker."""
+        tracker = get_usage_tracker()
+        tracker.check_ip_rate_limit("192.168.1.1")
+
+        # Get tracker again
+        tracker2 = get_usage_tracker()
+        diagnostics = tracker2.get_diagnostics()
+        assert diagnostics["unique_ips_today"] == 1
+
+
+class TestErrorMessages:
+    """Tests for user-friendly error messages."""
+
+    def test_rate_limit_message_is_user_friendly(self) -> None:
+        """Rate limit error has user-friendly message."""
+        error = RateLimitExceededError(ip_hash="abc123", limit=20)
+        assert "demo project" in error.message.lower()
+        assert "20" in error.message
+        assert "tomorrow" in error.message.lower()
+
+    def test_daily_budget_message_is_user_friendly(self) -> None:
+        """Daily budget error has user-friendly message."""
+        error = DailyBudgetExceededError(limit_type="LLM calls", used=100, limit=100)
+        assert "demo project" in error.message.lower()
+        assert "tomorrow" in error.message.lower()
+
+    def test_llm_disabled_message_is_user_friendly(self) -> None:
+        """LLM disabled error has user-friendly message."""
+        error = LLMDisabledError()
+        assert "disabled" in error.message.lower()
+        assert (
+            "maintenance" in error.suggestion.lower() or "intentional" in error.suggestion.lower()
+        )


### PR DESCRIPTION
## Summary

This PR implements strict usage limits to protect ForgeBreaker (a demo/portfolio project) from abuse and unexpected LLM costs.

### Cost Controls Added

**Per-IP Rate Limiting**
- 20 requests per day per IP address
- Returns HTTP 429 with user-friendly demo message
- IP addresses are hashed (SHA-256) for privacy in logs

**Global Daily LLM Budget**
- Max 500 LLM calls per day (configurable)
- Max 500,000 tokens per day (configurable)
- Returns HTTP 503 when exceeded

**Kill Switch**
- `LLM_ENABLED` environment variable
- Set to `false` to disable all LLM functionality immediately
- Useful for cost emergencies or maintenance

**Monitoring**
- `/diagnostics/usage-stats` endpoint shows current usage and remaining budget

### Implementation Details

- Thread-safe `DailyUsageTracker` with Lock
- Automatic reset at midnight UTC
- Enforced BEFORE any LLM logic runs
- All limits are HARD CAPS (no soft limits)

### INVARIANTS

- All limits are HARD CAPS, not soft limits
- Exceedance is TERMINAL — no retries, no fallback
- Limits are enforced BEFORE any LLM logic runs
- IP-based limits use hashed IPs for privacy in logs

## Test Plan

- [x] `ruff format --check .` passes
- [x] `ruff check .` passes
- [x] `pytest` passes (1273 tests, 84.23% coverage)
- [x] 27 new tests for cost controls

## Files Changed

| File | Change |
|------|--------|
| `forgebreaker/services/cost_controls.py` | New: Core cost control module |
| `forgebreaker/config.py` | Add cost control settings |
| `forgebreaker/api/chat.py` | Integrate cost controls |
| `forgebreaker/main.py` | Add exception handlers and diagnostics endpoint |
| `forgebreaker/services/__init__.py` | Export cost control classes |
| `tests/test_cost_controls.py` | New: 27 tests |
| `README.md` | Add "Usage Limits & Cost Controls" section |

🤖 Generated with [Claude Code](https://claude.com/claude-code)